### PR TITLE
Improved finite field multiplication, no more modulo reduction.

### DIFF
--- a/src/main/java/org/cryptimeleon/math/structures/rings/extfield/ExtensionFieldElement.java
+++ b/src/main/java/org/cryptimeleon/math/structures/rings/extfield/ExtensionFieldElement.java
@@ -83,19 +83,23 @@ public class ExtensionFieldElement implements FieldElement, UniqueByteRepresenta
 
     @Override
     public ExtensionFieldElement mul(Element e) {
-        ExtensionFieldElement bne = (ExtensionFieldElement) e;
+        ExtensionFieldElement other = (ExtensionFieldElement) e;
 
-        FieldElement[] result = new FieldElement[this.coefficients.length + bne.coefficients.length];
+        FieldElement[] result = new FieldElement[field.extensionDegree];
+        Arrays.fill(result, field.getBaseField().getZeroElement());
 
-        for (int i = 0; i < result.length; i++)
-            result[i] = this.getStructure().getBaseField().getZeroElement();
-
-        for (int i = 0; i < this.coefficients.length; i++)
-            for (int j = 0; j < bne.coefficients.length; j++) {
-                result[i + j] = result[i + j].add(this.coefficients[i].mul(bne.coefficients[j]));
+        for (int i = 0; i < this.coefficients.length; i++) {
+            FieldElement coefficient = this.coefficients[i];
+            for (int j=0; j < other.coefficients.length; j++) {
+                if (i+j < field.extensionDegree) {
+                    result[i+j] = result[i+j].add(coefficient.mul(other.coefficients[j]));
+                } else { //using that x^extensionDegree = -constant, so we write this as this[i]*other[j] * x^{i+j} = this[i]*other[j]*(-constant)*x^{i+j-extensionDegree}
+                    result[i+j-field.extensionDegree] = result[i+j-field.extensionDegree].sub(coefficient.mul(other.coefficients[j]).mul(field.constant));
+                }
             }
+        }
 
-        return this.getStructure().createElement(result);
+        return field.createElement(result);
     }
 
     /**

--- a/src/test/java/org/cryptimeleon/math/structures/RingTests.java
+++ b/src/test/java/org/cryptimeleon/math/structures/RingTests.java
@@ -3,6 +3,7 @@ package org.cryptimeleon.math.structures;
 import org.cryptimeleon.math.structures.rings.Field;
 import org.cryptimeleon.math.structures.rings.Ring;
 import org.cryptimeleon.math.structures.rings.RingElement;
+import org.cryptimeleon.math.structures.rings.extfield.ExtensionField;
 import org.cryptimeleon.math.structures.rings.integers.IntegerElement;
 import org.cryptimeleon.math.structures.rings.integers.IntegerRing;
 import org.cryptimeleon.math.structures.rings.polynomial.PolynomialRing;
@@ -241,6 +242,9 @@ public class RingTests extends StructureTests {
         // Polynomial ring over z13
         PolynomialRing polyRing = new PolynomialRing(z13);
 
+        // ExtensionField
+        ExtensionField extensionField = new ExtensionField(z13.getElement(11), 2);
+
         // Collect parameters
         TestParams[][] params = new TestParams[][]{
                 {new TestParams(integerRing, () -> new IntegerElement(5), () -> new IntegerElement(-1))},
@@ -251,7 +255,8 @@ public class RingTests extends StructureTests {
                         () -> polyRing.new Polynomial(new Random().nextBoolean() ? z13.getUniformlyRandomElement() :
                                 z13.getZeroElement(),
                                 z13.getUniformlyRandomElement()),
-                        polyRing::getUniformlyRandomUnit)}
+                        polyRing::getUniformlyRandomUnit)},
+                {new TestParams(extensionField)}
         };
         return Arrays.asList(params);
     }


### PR DESCRIPTION
Now we're using that x^extensionDegree is a constant in the subfield, which allows us to multiply much faster than having to modulo-reduce a degree 2*extensionDegree polynomial.