### PR TITLE
Added convenience methods

### DIFF
--- a/src/main/java/org/cryptimeleon/math/structures/cartesian/ExponentExpressionVector.java
+++ b/src/main/java/org/cryptimeleon/math/structures/cartesian/ExponentExpressionVector.java
@@ -115,7 +115,18 @@ public class ExponentExpressionVector extends Vector<ExponentExpr> {
         return new ExponentExpressionVector(super.truncate(newLength));
     }
 
+    @Override
     public ExponentExpressionVector concatenate(Vector<? extends ExponentExpr> secondPart) {
         return new ExponentExpressionVector(super.concatenate(secondPart));
+    }
+
+    @Override
+    public ExponentExpressionVector append(ExponentExpr valueToAppend) {
+        return new ExponentExpressionVector(super.append(valueToAppend));
+    }
+
+    @Override
+    public ExponentExpressionVector prepend(ExponentExpr valueToPrepend) {
+        return new ExponentExpressionVector(super.prepend(valueToPrepend));
     }
 }

--- a/src/main/java/org/cryptimeleon/math/structures/cartesian/GroupElementExpressionVector.java
+++ b/src/main/java/org/cryptimeleon/math/structures/cartesian/GroupElementExpressionVector.java
@@ -116,6 +116,16 @@ public class GroupElementExpressionVector extends Vector<GroupElementExpression>
     }
 
     @Override
+    public GroupElementExpressionVector append(GroupElementExpression valueToAppend) {
+        return new GroupElementExpressionVector(super.append(valueToAppend));
+    }
+
+    @Override
+    public GroupElementExpressionVector prepend(GroupElementExpression valueToPrepend) {
+        return new GroupElementExpressionVector(super.prepend(valueToPrepend));
+    }
+
+    @Override
     public GroupElementExpressionVector replace(int index, GroupElementExpression substitute) {
         return new GroupElementExpressionVector(super.replace(index, substitute));
     }

--- a/src/main/java/org/cryptimeleon/math/structures/cartesian/Vector.java
+++ b/src/main/java/org/cryptimeleon/math/structures/cartesian/Vector.java
@@ -302,6 +302,19 @@ public class Vector<X> {
         return instantiateWithSafeArray(result);
     }
 
+    public Vector<X> append(X valueToAppend) {
+        ArrayList<X> result = new ArrayList<>(values);
+        result.add(valueToAppend);
+        return instantiateWithSafeArray(result);
+    }
+
+    public Vector<X> prepend(X valueToPrepend) {
+        ArrayList<X> result = new ArrayList<>();
+        result.add(valueToPrepend);
+        result.addAll(values);
+        return instantiateWithSafeArray(result);
+    }
+
     public Vector<X> replace(int index, X substitute) {
         ArrayList<X> result = new ArrayList<>(values);
         result.set(index, substitute);

--- a/src/main/java/org/cryptimeleon/math/structures/groups/GroupElement.java
+++ b/src/main/java/org/cryptimeleon/math/structures/groups/GroupElement.java
@@ -1,5 +1,6 @@
 package org.cryptimeleon.math.structures.groups;
 
+import org.cryptimeleon.math.expressions.bool.BooleanExpression;
 import org.cryptimeleon.math.expressions.exponent.ExponentExpr;
 import org.cryptimeleon.math.expressions.group.GroupElementConstantExpr;
 import org.cryptimeleon.math.expressions.group.GroupElementExpression;
@@ -149,6 +150,42 @@ public interface GroupElement extends Element, UniqueByteRepresentable {
      */
     default GroupElementConstantExpr expr() {
         return new GroupElementConstantExpr(this);
+    }
+
+    /**
+     * Returns an expression of the form "this == expr".
+     * This is meant to write down an expression, usually only useful if you want to express something that depends on variables that become known later.
+     * If you just want to compare two {@link GroupElement}s, just use {@link #equals(Object)}.
+     *
+     * @param expr an expression to compare this group element to
+     * @return an expression the evaluates to true (for some variable instantiation) if this is equal to expr.
+     */
+    default BooleanExpression isEqualTo(GroupElementExpression expr) {
+        return expr().isEqualTo(expr);
+    }
+
+    /**
+     * Returns an expression of the form "this == expr".
+     * This is meant to write down an expression, usually only useful if you want to express something that depends on variables that become known later.
+     * If you just want to compare two {@link GroupElement}s, just use {@link #equals(Object)}.
+     *
+     * @param expr an expression to compare this group element to
+     * @return an expression the evaluates to true (for some variable instantiation) if this is equal to expr.
+     */
+    default BooleanExpression isEqualTo(String expr) {
+        return expr().isEqualTo(expr);
+    }
+
+    /**
+     * Returns an expression of the form "this == other".
+     * This is meant to write down an expression, usually only useful if you want to express something that depends on variables that become known later.
+     * If you just want to compare two {@link GroupElement}s, just use {@link #equals(Object)}.
+     *
+     * @param other another group element to compare this group element to
+     * @return an expression the evaluates to true iff this.equals(other).
+     */
+    default BooleanExpression isEqualTo(GroupElement other) {
+        return expr().isEqualTo(other);
     }
 
     /**

--- a/src/main/java/org/cryptimeleon/math/structures/groups/cartesian/GroupElementVector.java
+++ b/src/main/java/org/cryptimeleon/math/structures/groups/cartesian/GroupElementVector.java
@@ -126,8 +126,19 @@ public class GroupElementVector extends Vector<GroupElement> implements Represen
         return new GroupElementVector(super.truncate(newLength));
     }
 
+    @Override
     public GroupElementVector concatenate(Vector<? extends GroupElement> secondPart) {
         return new GroupElementVector(super.concatenate(secondPart));
+    }
+
+    @Override
+    public GroupElementVector append(GroupElement valueToAppend) {
+        return new GroupElementVector(super.append(valueToAppend));
+    }
+
+    @Override
+    public GroupElementVector prepend(GroupElement valueToPrepend) {
+        return new GroupElementVector(super.prepend(valueToPrepend));
     }
 
     public static GroupElementVector fromStream(Stream<? extends GroupElement> stream) {

--- a/src/main/java/org/cryptimeleon/math/structures/rings/cartesian/RingElementVector.java
+++ b/src/main/java/org/cryptimeleon/math/structures/rings/cartesian/RingElementVector.java
@@ -126,8 +126,19 @@ public class RingElementVector extends Vector<RingElement> implements Representa
         return new RingElementVector(super.truncate(newLength));
     }
 
+    @Override
     public RingElementVector concatenate(Vector<? extends RingElement> secondPart) {
         return new RingElementVector(super.concatenate(secondPart));
+    }
+
+    @Override
+    public RingElementVector append(RingElement valueToAppend) {
+        return new RingElementVector(super.append(valueToAppend));
+    }
+
+    @Override
+    public RingElementVector prepend(RingElement valueToPrepend) {
+        return new RingElementVector(super.prepend(valueToPrepend));
     }
 
     public ProductRingElement asElementInProductRing() {

--- a/src/main/java/org/cryptimeleon/math/structures/rings/integers/IntegerRing.java
+++ b/src/main/java/org/cryptimeleon/math/structures/rings/integers/IntegerRing.java
@@ -139,4 +139,29 @@ public class IntegerRing implements Ring {
 
         return result;
     }
+
+    /**
+     * Decomposes a given number into digits with the given base.
+     * <p>
+     * For example, for base = 2, this does bit decomposition.
+     *
+     * @return an array {@code A} containing values {@code A[i] < base} such that
+     *         \(\sum_i{ \text{A}[i] \cdot \text{base}^i} = \text{number}\)
+     */
+    public static BigInteger[] decomposeIntoDigits(BigInteger number, long base) {
+        return decomposeIntoDigits(number, BigInteger.valueOf(base));
+    }
+
+    /**
+     * Decomposes a given number into the given number of digits with the given base.
+     * <p>
+     * For example, for base = 2, this does bit decomposition.
+     *
+     * @return an array {@code A} containing values {@code A[i] < base} such that
+     *         \(\sum_i{ \text{A}[i] \cdot \text{base}^i} = \text{number}\)
+     * @throws IllegalArgumentException if {@code numDigits} is not enough to represent the given number
+     */
+    public static BigInteger[] decomposeIntoDigits(BigInteger number, long base, int numDigits) {
+        return decomposeIntoDigits(number, BigInteger.valueOf(base), numDigits);
+    }
 }

--- a/src/main/java/org/cryptimeleon/math/structures/rings/zn/Zn.java
+++ b/src/main/java/org/cryptimeleon/math/structures/rings/zn/Zn.java
@@ -1,6 +1,9 @@
 package org.cryptimeleon.math.structures.rings.zn;
 
+import org.cryptimeleon.math.expressions.bool.BooleanExpression;
+import org.cryptimeleon.math.expressions.bool.ExponentEqualityExpr;
 import org.cryptimeleon.math.expressions.exponent.ExponentConstantExpr;
+import org.cryptimeleon.math.expressions.exponent.ExponentExpr;
 import org.cryptimeleon.math.hash.ByteAccumulator;
 import org.cryptimeleon.math.hash.UniqueByteRepresentable;
 import org.cryptimeleon.math.random.RandomGenerator;
@@ -293,6 +296,42 @@ public class Zn implements Ring {
 
         public ExponentConstantExpr asExponentExpression() {
             return new ExponentConstantExpr(this);
+        }
+
+        /**
+         * Returns an expression "this = other".
+         * This is for building expressions, i.e. only useful if unknown variables are involved.
+         * To compare two {@linkplain ZnElement}s normally, just use {@link #equals(Object)}.
+         */
+        public ExponentEqualityExpr isEqualTo(ExponentExpr other) {
+            return asExponentExpression().isEqualTo(other);
+        }
+
+        /**
+         * Returns an expression "this = other".
+         * This is for building expressions, i.e. only useful if unknown variables are involved.
+         * To compare two {@linkplain ZnElement}s normally, just use {@link #equals(Object)}.
+         */
+        public ExponentEqualityExpr isEqualTo(ZnElement other) {
+            return isEqualTo(other.asExponentExpression());
+        }
+
+        /**
+         * Returns an expression "this = other mod n".
+         * This is for building expressions, i.e. only useful if unknown variables are involved.
+         * To compare two {@linkplain ZnElement}s normally, just use {@link #equals(Object)}.
+         */
+        public ExponentEqualityExpr isEqualTo(BigInteger other) {
+            return isEqualTo(valueOf(other));
+        }
+
+        /**
+         * Returns an expression "this = other mod n".
+         * This is for building expressions, i.e. only useful if unknown variables are involved.
+         * To compare two {@linkplain ZnElement}s normally, just use {@link #equals(Object)}.
+         */
+        public ExponentEqualityExpr isEqualTo(long other) {
+            return isEqualTo(valueOf(other));
         }
 
         @Override

--- a/src/main/java/org/cryptimeleon/math/structures/rings/zn/Zn.java
+++ b/src/main/java/org/cryptimeleon/math/structures/rings/zn/Zn.java
@@ -172,6 +172,10 @@ public class Zn implements Ring {
             return createZnElementUnsafe(result);
         }
 
+        public ExponentExpr add(ExponentExpr e) {
+            return asExponentExpression().add(e);
+        }
+
         @Override
         public ZnElement neg() {
             return v.equals(BigInteger.ZERO) ? this : createZnElementUnsafe(n.subtract(v));
@@ -184,6 +188,10 @@ public class Zn implements Ring {
             if (result.signum() == -1)
                 result = result.add(n);
             return createZnElementUnsafe(result);
+        }
+
+        public ExponentExpr sub(ExponentExpr e) {
+            return asExponentExpression().sub(e);
         }
 
         @Override
@@ -202,6 +210,10 @@ public class Zn implements Ring {
             return mul(BigInteger.valueOf(k));
         }
 
+        public ExponentExpr mul(ExponentExpr e) {
+            return asExponentExpression().mul(e);
+        }
+
         @Override
         public ZnElement pow(BigInteger k) {
             return createZnElementUnsafe(v.modPow(k, n));
@@ -210,6 +222,10 @@ public class Zn implements Ring {
         @Override
         public ZnElement pow(long k) {
             return pow(BigInteger.valueOf(k));
+        }
+
+        public ExponentExpr pow(ExponentExpr e) {
+            return asExponentExpression().pow(e);
         }
 
         @Override


### PR DESCRIPTION
See title. 

The reason for this is mostly the zero-knowledge compiler developed by Jeremy. For the generated code there, there should not be a need to explicitly cast a group element to an expression using `.expr()`. Everything else (`pow(), op(), ...`) is already overloaded in the same way as `.isEqualTo()` now is. 