### PR TITLE
Fix debug toString methods

### DIFF
--- a/src/main/java/org/cryptimeleon/math/structures/groups/debug/DebugBilinearMap.java
+++ b/src/main/java/org/cryptimeleon/math/structures/groups/debug/DebugBilinearMap.java
@@ -129,9 +129,9 @@ public class DebugBilinearMap implements BilinearMap {
     @Override
     public String toString() {
         if (isSymmetric()) {
-            return "Symmetric CountingBilinearMap(" + totalBilMap + ";" + expMultiExpBilMap + ")";
+            return "Symmetric" +  this.getClass().getSimpleName() + "(" + totalBilMap + ";" + expMultiExpBilMap + ")";
         } else {
-            return "Asymmetric CountingBilinearMap(" + totalBilMap + ";" + expMultiExpBilMap + ")";
+            return "Asymmetric" +  this.getClass().getSimpleName() + "(" + totalBilMap + ";" + expMultiExpBilMap + ")";
         }
     }
 

--- a/src/main/java/org/cryptimeleon/math/structures/groups/debug/DebugBilinearMap.java
+++ b/src/main/java/org/cryptimeleon/math/structures/groups/debug/DebugBilinearMap.java
@@ -129,9 +129,9 @@ public class DebugBilinearMap implements BilinearMap {
     @Override
     public String toString() {
         if (isSymmetric()) {
-            return "Symmetric" +  this.getClass().getSimpleName() + "(" + totalBilMap + ";" + expMultiExpBilMap + ")";
+            return "Symmetric " +  this.getClass().getSimpleName() + "(" + totalBilMap + ";" + expMultiExpBilMap + ")";
         } else {
-            return "Asymmetric" +  this.getClass().getSimpleName() + "(" + totalBilMap + ";" + expMultiExpBilMap + ")";
+            return "Asymmetric " +  this.getClass().getSimpleName() + "(" + totalBilMap + ";" + expMultiExpBilMap + ")";
         }
     }
 

--- a/src/main/java/org/cryptimeleon/math/structures/groups/debug/DebugGroup.java
+++ b/src/main/java/org/cryptimeleon/math/structures/groups/debug/DebugGroup.java
@@ -241,6 +241,6 @@ public class DebugGroup implements Group {
 
     @Override
     public String toString() {
-        return "CountingGroup(" + groupTotal + ";" + groupExpMultiExp + ")";
+        return this.getClass().getSimpleName() + "(" + groupTotal + ";" + groupExpMultiExp + ")";
     }
 }


### PR DESCRIPTION
Fixes some `toString` methods in the debug classes which still referred to "CountingGroup" instead of "DebugGroup".