### PR TITLE
Adds new indifferentiable hash function for hashing to BarretoNaehrig G1 and G2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Implemented new indifferentiable hash functions to G1 and G2 for Barreto-Naehrig bilinear groups
+
 ### Changed
 - Renamed counting group classes and package to debug
 

--- a/src/main/java/org/cryptimeleon/math/hash/impl/VariableOutputLengthHashFunction.java
+++ b/src/main/java/org/cryptimeleon/math/hash/impl/VariableOutputLengthHashFunction.java
@@ -7,6 +7,7 @@ import org.cryptimeleon.math.serialization.annotations.ReprUtil;
 import org.cryptimeleon.math.serialization.annotations.Represented;
 
 import java.nio.ByteBuffer;
+import java.util.Objects;
 
 /**
  * A hash function with variable output length.
@@ -53,7 +54,7 @@ public class VariableOutputLengthHashFunction implements HashFunction, Standalon
      * Initializes this instance using a specific base hash function and output length.
      *
      * @param hashFunction the base hash function
-     * @param outputLength thedesired output length of this hash function in number of bytes
+     * @param outputLength the desired output length of this hash function in number of bytes
      */
     public VariableOutputLengthHashFunction(HashFunction hashFunction, int outputLength) {
         innerFunction = hashFunction;
@@ -85,7 +86,6 @@ public class VariableOutputLengthHashFunction implements HashFunction, Standalon
         //  given a collision (x,x'), either innerFunction(0||x) = innerFunction(0||x')
         //  or innerFunction(1 || innerFunction(0||x)) = innerFunction(1 || innerFunction(0||x')).
         //  We have found a collision in both cases.
-
         byte[] result = new byte[outputLength];
         int bytesFilled = 0;
         byte[] y = innerFunction.hash(prependInt(0, x));
@@ -121,11 +121,7 @@ public class VariableOutputLengthHashFunction implements HashFunction, Standalon
 
     @Override
     public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + ((innerFunction == null) ? 0 : innerFunction.hashCode());
-        result = prime * result + outputLength;
-        return result;
+        return Objects.hash(innerFunction, outputLength);
     }
 
     @Override
@@ -136,15 +132,8 @@ public class VariableOutputLengthHashFunction implements HashFunction, Standalon
             return false;
         if (getClass() != obj.getClass())
             return false;
-        VariableOutputLengthHashFunction other = (VariableOutputLengthHashFunction) obj;
-        if (innerFunction == null) {
-            if (other.innerFunction != null)
-                return false;
-        } else if (!innerFunction.equals(other.innerFunction))
-            return false;
-        if (outputLength != other.outputLength)
-            return false;
-        return true;
+        VariableOutputLengthHashFunction that = (VariableOutputLengthHashFunction) obj;
+        return Objects.equals(innerFunction, that.innerFunction) &&
+                Objects.equals(outputLength, that.outputLength);
     }
-
 }

--- a/src/main/java/org/cryptimeleon/math/structures/groups/elliptic/PairingSourceGroupImpl.java
+++ b/src/main/java/org/cryptimeleon/math/structures/groups/elliptic/PairingSourceGroupImpl.java
@@ -156,13 +156,15 @@ public abstract class PairingSourceGroupImpl implements WeierstrassCurve {
     /**
      * Tests if (x,y) is a member of this (sub)group.
      * <p>
-     * This function first checks of (x,y) defines a point on the curve that defines this group. Then a subgroup membership test is performed by multiplication either with the group order or with the cofactor. If both are large, this is an expensive
-     * operation.
+     * This function first checks of (x,y) defines a point on the curve that defines this group.
+     * Then a subgroup membership test is performed by multiplication either with the group order or with the cofactor.
+     * If both are large, this is an expensive operation.
      * <p>
-     * For cryptographic protocols where x and y are inputs to the algorithm, a subgroup membership test is mandatory to avoid small subgroup attacks, twist attacks,...
+     * For cryptographic protocols where x and y are inputs to the algorithm, a subgroup membership test is mandatory
+     * to avoid small subgroup attacks, twist attacks,...
      *
-     * @param x - x-coordinate of point to be checked
-     * @param y - y-coordinate of point to be checked
+     * @param x x-coordinate of point to be checked
+     * @param y y-coordinate of point to be checked
      * @return true if (x,y) is on curve
      */
     public boolean isMember(FieldElement x, FieldElement y) {
@@ -240,14 +242,25 @@ public abstract class PairingSourceGroupImpl implements WeierstrassCurve {
      * @param y second coordinate of the point to map
      * @return a point in this subgroup
      */
-    protected PairingSourceGroupElement cofactorMultiplication(FieldElement x, FieldElement y) {
+    public PairingSourceGroupElement multiplyByCofactor(FieldElement x, FieldElement y) {
         PairingSourceGroupElement elem = getElement(x, y);
+        return multiplyByCofactor(elem);
+    }
 
+    /**
+     * Maps a point (x,y) on the curve into the subgroup represented by this object.
+     * Note that pow() on a PairingSourceGroupElement does not work if pow() depends on
+     * the group size (which it may, e.g., to first reduce the exponent mod size()).
+     *
+     * @param element the curve element to map to the subgroup
+     * @return a point in this subgroup
+     */
+    public PairingSourceGroupElement multiplyByCofactor(GroupElementImpl element) {
         GroupElementImpl result = getNeutralElement();
         for (int i = cofactor.bitLength() - 1; i >= 0; i--) {
             result = result.op(result);
             if (cofactor.testBit(i))
-                result = result.op(elem);
+                result = result.op(element);
         }
         return (PairingSourceGroupElement) result;
     }

--- a/src/main/java/org/cryptimeleon/math/structures/groups/elliptic/type1/supersingular/SupersingularSourceGroupImpl.java
+++ b/src/main/java/org/cryptimeleon/math/structures/groups/elliptic/type1/supersingular/SupersingularSourceGroupImpl.java
@@ -81,7 +81,7 @@ class SupersingularSourceGroupImpl extends PairingSourceGroupImpl {
         }
 
         /*now we need to map the point (x,y) on the curve to our subgroup and return it*/
-        return (SupersingularSourceGroupElementImpl) cofactorMultiplication(x, y);
+        return (SupersingularSourceGroupElementImpl) multiplyByCofactor(x, y);
     }
 
     @Override

--- a/src/main/java/org/cryptimeleon/math/structures/groups/elliptic/type3/bn/BarretoNaehrigBilinearGroupImpl.java
+++ b/src/main/java/org/cryptimeleon/math/structures/groups/elliptic/type3/bn/BarretoNaehrigBilinearGroupImpl.java
@@ -53,9 +53,9 @@ class BarretoNaehrigBilinearGroupImpl implements BilinearGroupImpl {
     @Represented
     private BarretoNaehrigTargetGroupImpl gtimpl;
     @Represented
-    private BarretoNaehrigHashToG1Impl hashIntoG1impl;
+    private BarretoNaehrigHashToSourceGroupImpl hashIntoG1impl;
     @Represented
-    private BarretoNaehrigPointEncoding hashIntoG2impl;
+    private BarretoNaehrigHashToSourceGroupImpl hashIntoG2impl;
 
     private BarretoNaehrigTatePairing bilinearMapImpl;
 
@@ -140,9 +140,8 @@ class BarretoNaehrigBilinearGroupImpl implements BilinearGroupImpl {
             default:
                 throw new IllegalArgumentException("Unknown hash function " + spec.hash);
         }
-        // Why does the spec supply the hash function?
-        hashIntoG1impl = new BarretoNaehrigHashToG1Impl(g1impl);
-        hashIntoG2impl = new BarretoNaehrigPointEncoding(hash, g2impl);
+        hashIntoG1impl = new BarretoNaehrigHashToSourceGroupImpl(g1impl, hash);
+        hashIntoG2impl = new BarretoNaehrigHashToSourceGroupImpl(g2impl, hash);
 
         /* construct new bilinearMap based on its name */
         if ("Tate".equals(spec.pairing)) {
@@ -418,8 +417,8 @@ class BarretoNaehrigBilinearGroupImpl implements BilinearGroupImpl {
         gtimpl = gT;
 
         bilinearMapImpl = new BarretoNaehrigTatePairing(g1impl, g2impl, gT, u);
-        hashIntoG1impl = new BarretoNaehrigHashToG1Impl(g1impl);
-        hashIntoG2impl = new BarretoNaehrigPointEncoding(g2impl);
+        hashIntoG1impl = new BarretoNaehrigHashToSourceGroupImpl(g1impl);
+        hashIntoG2impl = new BarretoNaehrigHashToSourceGroupImpl(g2impl);
     }
 
     /**

--- a/src/main/java/org/cryptimeleon/math/structures/groups/elliptic/type3/bn/BarretoNaehrigBilinearGroupImpl.java
+++ b/src/main/java/org/cryptimeleon/math/structures/groups/elliptic/type3/bn/BarretoNaehrigBilinearGroupImpl.java
@@ -53,7 +53,7 @@ class BarretoNaehrigBilinearGroupImpl implements BilinearGroupImpl {
     @Represented
     private BarretoNaehrigTargetGroupImpl gtimpl;
     @Represented
-    private BarretoNaehrigPointEncoding hashIntoG1impl;
+    private BarretoNaehrigHashToG1Impl hashIntoG1impl;
     @Represented
     private BarretoNaehrigPointEncoding hashIntoG2impl;
 
@@ -140,7 +140,8 @@ class BarretoNaehrigBilinearGroupImpl implements BilinearGroupImpl {
             default:
                 throw new IllegalArgumentException("Unknown hash function " + spec.hash);
         }
-        hashIntoG1impl = new BarretoNaehrigPointEncoding(hash, g1impl);
+        // Why does the spec supply the hash function?
+        hashIntoG1impl = new BarretoNaehrigHashToG1Impl(g1impl);
         hashIntoG2impl = new BarretoNaehrigPointEncoding(hash, g2impl);
 
         /* construct new bilinearMap based on its name */
@@ -200,7 +201,7 @@ class BarretoNaehrigBilinearGroupImpl implements BilinearGroupImpl {
     }
 
     @Override
-    public HashIntoGroupImpl getHashIntoG1() throws UnsupportedOperationException {
+    public HashIntoGroupImpl getHashIntoG1() {
         return this.hashIntoG1impl;
     }
 
@@ -417,7 +418,7 @@ class BarretoNaehrigBilinearGroupImpl implements BilinearGroupImpl {
         gtimpl = gT;
 
         bilinearMapImpl = new BarretoNaehrigTatePairing(g1impl, g2impl, gT, u);
-        hashIntoG1impl = new BarretoNaehrigPointEncoding(g1impl);
+        hashIntoG1impl = new BarretoNaehrigHashToG1Impl(g1impl);
         hashIntoG2impl = new BarretoNaehrigPointEncoding(g2impl);
     }
 

--- a/src/main/java/org/cryptimeleon/math/structures/groups/elliptic/type3/bn/BarretoNaehrigHashToG1Impl.java
+++ b/src/main/java/org/cryptimeleon/math/structures/groups/elliptic/type3/bn/BarretoNaehrigHashToG1Impl.java
@@ -1,10 +1,10 @@
 package org.cryptimeleon.math.structures.groups.elliptic.type3.bn;
 
-import org.cryptimeleon.math.hash.ByteAccumulator;
 import org.cryptimeleon.math.hash.HashFunction;
-import org.cryptimeleon.math.hash.impl.ByteArrayAccumulator;
 import org.cryptimeleon.math.hash.impl.VariableOutputLengthHashFunction;
 import org.cryptimeleon.math.serialization.Representation;
+import org.cryptimeleon.math.serialization.annotations.ReprUtil;
+import org.cryptimeleon.math.serialization.annotations.Represented;
 import org.cryptimeleon.math.structures.groups.GroupElementImpl;
 import org.cryptimeleon.math.structures.groups.mappings.impl.HashIntoGroupImpl;
 import org.cryptimeleon.math.structures.rings.Field;
@@ -13,27 +13,41 @@ import org.cryptimeleon.math.structures.rings.helpers.FiniteFieldTools;
 import org.cryptimeleon.math.structures.rings.zn.Zn;
 
 import java.math.BigInteger;
+import java.util.Objects;
 
 /**
  * Indifferentiable encoding, that is, an encoding that can be used to implement a hash function that can be used
  * to replace a ROM. More general than Boneh-Franklin admissible in that regard.
  */
-public class BarretoNaehrigHashToG1Impl implements HashIntoGroupImpl {
+class BarretoNaehrigHashToG1Impl implements HashIntoGroupImpl {
 
-    private final BarretoNaehrigGroup1Impl group1Impl;
-    private final Field baseField;
-    private final FieldElement b;
+    @Represented
+    public BarretoNaehrigGroup1Impl group1Impl;
+    private Field baseField;
+    private FieldElement b;
 
-    private final FieldElement c1;
-    private final FieldElement c2;
+    private FieldElement c1;
+    private FieldElement c2;
 
-    private final HashFunction hashFunction;
+    private HashFunction hashFunction1;
+    private HashFunction hashFunction2;
 
     public BarretoNaehrigHashToG1Impl(BarretoNaehrigGroup1Impl group1Impl) {
         this.group1Impl = group1Impl;
+        init();
+    }
+
+    public BarretoNaehrigHashToG1Impl(Representation repr) {
+        new ReprUtil(this).deserialize(repr);
+        init();
+    }
+
+    public void init() {
         b = group1Impl.getA6();
         baseField = group1Impl.getFieldOfDefinition();
-        hashFunction = new VariableOutputLengthHashFunction((baseField.size().bitLength() - 1) / 8);
+        hashFunction1 = new VariableOutputLengthHashFunction((baseField.size().bitLength() - 1) / 8);
+        // TODO: Need an independent hash function. Using the same two functions does not fulfill that.
+        hashFunction2 = new VariableOutputLengthHashFunction((baseField.size().bitLength() - 1) / 8);
         // c1 = sqrt{-3}
         c1 = FiniteFieldTools.sqrt(baseField.getElement(-3));
         // c2 = (-1 + sqrt{-3})/2
@@ -43,11 +57,18 @@ public class BarretoNaehrigHashToG1Impl implements HashIntoGroupImpl {
     @Override
     public GroupElementImpl hashIntoGroupImpl(byte[] x) {
         // Hashes given bytes to field element and applies SW encoding to it
-        ByteAccumulator accumulator = new ByteArrayAccumulator();
-        accumulator.append(x);
-        byte[] h = hashFunction.hash(accumulator.extractBytes());
-        BigInteger b = new BigInteger(h);
-        return SWEncode(baseField.getElement(b));
+        // Don't need any cofactor multiplication since the cofactor is always 1 for G1
+        // To get indifferentiability (Fouque and Tibouchi, Section 5), we need to
+        //  calculate f(h1(m)) + f(h2(m)),
+        //  where f is the SW encoding and h1 and h2 are independent random oracles to F_q.
+        byte[] h1 = hashFunction1.hash(x);
+        BigInteger i1 = new BigInteger(h1);
+        byte[] h2 = hashFunction2.hash(x);
+        BigInteger i2 = new BigInteger(h2);
+
+        GroupElementImpl result = SWEncode(baseField.getElement(i1)).op(SWEncode(baseField.getElement(i2)));
+        System.out.println(result.pow(group1Impl.getCofactor()));
+        return result;
     }
 
     /**
@@ -60,6 +81,10 @@ public class BarretoNaehrigHashToG1Impl implements HashIntoGroupImpl {
      * @param t the input
      */
     private GroupElementImpl SWEncode(FieldElement t) {
+        if (t.isZero()) {
+            // f(0) = ((-1 + \sqrt{-3})/2, \sqrt{1+b}) as suggested by Fouque and Tibouchi, Section 3
+            return group1Impl.getElement(c2, FiniteFieldTools.sqrt(baseField.getOneElement().add(b)));
+        }
         // w = sqrt{-3} * t/(1+b+t^2)
         FieldElement w = baseField.getOneElement().add(group1Impl.getA6().add(t.pow(2))).inv().mul(t).mul(c1);
         // x_1 = (-1 + sqrt{-3})/2 - tw
@@ -112,7 +137,20 @@ public class BarretoNaehrigHashToG1Impl implements HashIntoGroupImpl {
     }
 
     @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        BarretoNaehrigHashToG1Impl that = (BarretoNaehrigHashToG1Impl) o;
+        return Objects.equals(group1Impl, that.group1Impl);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(group1Impl, hashFunction1, hashFunction2);
+    }
+
+    @Override
     public Representation getRepresentation() {
-        return null;
+        return ReprUtil.serialize(this);
     }
 }

--- a/src/main/java/org/cryptimeleon/math/structures/groups/elliptic/type3/bn/BarretoNaehrigHashToG1Impl.java
+++ b/src/main/java/org/cryptimeleon/math/structures/groups/elliptic/type3/bn/BarretoNaehrigHashToG1Impl.java
@@ -1,0 +1,118 @@
+package org.cryptimeleon.math.structures.groups.elliptic.type3.bn;
+
+import org.cryptimeleon.math.hash.ByteAccumulator;
+import org.cryptimeleon.math.hash.HashFunction;
+import org.cryptimeleon.math.hash.impl.ByteArrayAccumulator;
+import org.cryptimeleon.math.hash.impl.VariableOutputLengthHashFunction;
+import org.cryptimeleon.math.serialization.Representation;
+import org.cryptimeleon.math.structures.groups.GroupElementImpl;
+import org.cryptimeleon.math.structures.groups.mappings.impl.HashIntoGroupImpl;
+import org.cryptimeleon.math.structures.rings.Field;
+import org.cryptimeleon.math.structures.rings.FieldElement;
+import org.cryptimeleon.math.structures.rings.helpers.FiniteFieldTools;
+import org.cryptimeleon.math.structures.rings.zn.Zn;
+
+import java.math.BigInteger;
+
+/**
+ * Indifferentiable encoding, that is, an encoding that can be used to implement a hash function that can be used
+ * to replace a ROM. More general than Boneh-Franklin admissible in that regard.
+ */
+public class BarretoNaehrigHashToG1Impl implements HashIntoGroupImpl {
+
+    private final BarretoNaehrigGroup1Impl group1Impl;
+    private final Field baseField;
+    private final FieldElement b;
+
+    private final FieldElement c1;
+    private final FieldElement c2;
+
+    private final HashFunction hashFunction;
+
+    public BarretoNaehrigHashToG1Impl(BarretoNaehrigGroup1Impl group1Impl) {
+        this.group1Impl = group1Impl;
+        b = group1Impl.getA6();
+        baseField = group1Impl.getFieldOfDefinition();
+        hashFunction = new VariableOutputLengthHashFunction((baseField.size().bitLength() - 1) / 8);
+        // c1 = sqrt{-3}
+        c1 = FiniteFieldTools.sqrt(baseField.getElement(-3));
+        // c2 = (-1 + sqrt{-3})/2
+        c2 = baseField.getOneElement().neg().add(c1).div(baseField.getElement(2));
+    }
+
+    @Override
+    public GroupElementImpl hashIntoGroupImpl(byte[] x) {
+        // Hashes given bytes to field element and applies SW encoding to it
+        ByteAccumulator accumulator = new ByteArrayAccumulator();
+        accumulator.append(x);
+        byte[] h = hashFunction.hash(accumulator.extractBytes());
+        BigInteger b = new BigInteger(h);
+        return SWEncode(baseField.getElement(b));
+    }
+
+    /**
+     * Takes in a field element t and applied the Shallue-van de Woestijne encoding to it to obtain
+     * an element of the group G1.
+     * <p>
+     * This is the version designed to be secure against side-channel analysis and other physical attacks.
+     * <p>
+     * Implements algorithm 1 of P.-A. Fouque and M. Tibouchi, "Indifferentiable Hashing to Barreto–Naehrig Curves"
+     * @param t the input
+     */
+    private GroupElementImpl SWEncode(FieldElement t) {
+        // w = sqrt{-3} * t/(1+b+t^2)
+        FieldElement w = baseField.getOneElement().add(group1Impl.getA6().add(t.pow(2))).inv().mul(t).mul(c1);
+        // x_1 = (-1 + sqrt{-3})/2 - tw
+        FieldElement x1 = c2.add(t.mul(w).neg());
+        // x_2 = -1 - x_1
+        FieldElement x2 = baseField.getOneElement().neg().add(x1.neg());
+        // x_3 = 1 + 1/w^2
+        FieldElement x3 = baseField.getOneElement().add(baseField.getOneElement().div(w.square()));
+        // r_1, r_2, r_3 <-$ F_q^*
+        FieldElement r1 = baseField.getUniformlyRandomUnit();
+        FieldElement r2 = baseField.getUniformlyRandomUnit();
+        FieldElement r3 = baseField.getUniformlyRandomUnit();
+        // alpha = chi_q(r_1^2 * (x_1^3 + b))
+        int alpha = chi(r1.square().mul(x1.pow(3).add(b)));
+        // beta = chi_q(r_2^2 * (x_2^3 + b))
+        int beta = chi(r2.square().mul(x2.pow(3).add(b)));
+        // i = [(alpha - 1) * beta mod 3] + 1
+        Zn z3 = new Zn(BigInteger.valueOf(3));
+        int i = z3.createZnElement(BigInteger.valueOf((alpha - 1) * beta))
+                .getInteger()
+                .add(BigInteger.ONE)
+                .intValueExact();
+        // y = chi_q(r3^2 * t) * sqrt{x_i^3 + b}
+        FieldElement y;
+        if (i == 1) {
+            y = baseField.getElement(chi(r3.square().mul(t))).mul(FiniteFieldTools.sqrt(x1.pow(3).add(b)));
+            return group1Impl.getElement(x1, y);
+        } else if (i == 2) {
+            y = baseField.getElement(chi(r3.square().mul(t))).mul(FiniteFieldTools.sqrt(x2.pow(3).add(b)));
+            return group1Impl.getElement(x2, y);
+        } else if (i == 3) {
+            y = baseField.getElement(chi(r3.square().mul(t))).mul(FiniteFieldTools.sqrt(x3.pow(3).add(b)));
+            return group1Impl.getElement(x3, y);
+        }
+        throw new IllegalStateException("Unreachable!");
+    }
+
+    /**
+     * Implements character function chi_q of F_q^* extended with zero.
+     */
+    private int chi(FieldElement t) {
+        if (t.equals(baseField.getZeroElement())) {
+            return 0;
+        }
+        if (FiniteFieldTools.isSquare(t)) {
+            return 1;
+        } else {
+            return -1;
+        }
+    }
+
+    @Override
+    public Representation getRepresentation() {
+        return null;
+    }
+}

--- a/src/main/java/org/cryptimeleon/math/structures/groups/elliptic/type3/bn/BarretoNaehrigHashToSourceGroupImpl.java
+++ b/src/main/java/org/cryptimeleon/math/structures/groups/elliptic/type3/bn/BarretoNaehrigHashToSourceGroupImpl.java
@@ -15,6 +15,14 @@ import org.cryptimeleon.math.structures.rings.zn.Zn;
 import java.math.BigInteger;
 import java.util.Objects;
 
+/**
+ * Class for indifferentiable hashing to G1 and G2 of the Barreto-Naehrig bilinear group.
+ * <p>
+ * Indifferentiable means that the resulting hash function is indifferentiable from a random oracle.
+ * <p>
+ * Hashing is done via the Shallue-van de Woestijne encoding from P.-A. Fouque and M. Tibouchi:
+ * "Indifferentiable Hashing to Barreto–Naehrig Curves".
+ */
 class BarretoNaehrigHashToSourceGroupImpl implements HashIntoGroupImpl {
 
     @Represented
@@ -69,6 +77,7 @@ class BarretoNaehrigHashToSourceGroupImpl implements HashIntoGroupImpl {
         BigInteger i2 = new BigInteger(h2);
 
         GroupElementImpl result = SWEncode(baseField.getElement(i1)).op(SWEncode(baseField.getElement(i2)));
+        // Make sure that the resulting element is in the correct subgroup
         return groupImpl.multiplyByCofactor(result);
     }
 
@@ -147,7 +156,6 @@ class BarretoNaehrigHashToSourceGroupImpl implements HashIntoGroupImpl {
             return -1;
         }
     }
-
 
     @Override
     public boolean equals(Object o) {

--- a/src/main/java/org/cryptimeleon/math/structures/groups/elliptic/type3/bn/BarretoNaehrigSourceGroupImpl.java
+++ b/src/main/java/org/cryptimeleon/math/structures/groups/elliptic/type3/bn/BarretoNaehrigSourceGroupImpl.java
@@ -59,7 +59,7 @@ abstract class BarretoNaehrigSourceGroupImpl extends PairingSourceGroupImpl {
             throw new IllegalArgumentException("Require cofactor coprime to order of subgroup.");
         }
 
-        return cofactorMultiplication(this.decompressX(y, sel), y);
+        return multiplyByCofactor(this.decompressX(y, sel), y);
     }
 
     /**


### PR DESCRIPTION
New hash functions will be admissible in the sense that they can be used to replace a random oracle in any scheme in the ROM.

# Done
- Added hash function to G1, G2. I integrated it into our BN implementation and tested that it actually produces points on G1, respectively G2. Both are combined in a single class `BarretoNaehrigHashToSourceGroupImpl`. Cofactor multiplication is used from `PairingSourceGroupImpl`. To enable that, I had to make the cofactor multiplication method public so the hash class can access it.
- Some Javadocs
- Added to changelog

# TODO
- Could implement faster cofactor multiplication for G2. Right now we just seem to always use a simple binary square and multiply algorithm.