### PR TITLE
Make library compatible with Android version < S and implement Github action for running tests on Android emulator

### DIFF
--- a/.github/workflows/dev-ci.yaml
+++ b/.github/workflows/dev-ci.yaml
@@ -19,7 +19,7 @@ jobs:
         with:
           java-version: 1.8
       - name: Build with Gradle
-        run: ./gradlew :build -PcheckoutIfCloned
+        run: ./gradlew :build
   android:
     runs-on: macos-latest
     steps:

--- a/.github/workflows/dev-ci.yaml
+++ b/.github/workflows/dev-ci.yaml
@@ -20,3 +20,13 @@ jobs:
           java-version: 1.8
       - name: Build with Gradle
         run: ./gradlew build -PcheckoutIfCloned
+  android:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run tests on emulator
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 28
+          script: ./gradlew android-test:connectedAndroidTest -Pandroid.useAndroidX=true --info
+

--- a/.github/workflows/dev-ci.yaml
+++ b/.github/workflows/dev-ci.yaml
@@ -19,7 +19,7 @@ jobs:
         with:
           java-version: 1.8
       - name: Build with Gradle
-        run: ./gradlew build -PcheckoutIfCloned
+        run: ./gradlew :build -PcheckoutIfCloned
   android:
     runs-on: macos-latest
     steps:

--- a/.github/workflows/pub.yaml
+++ b/.github/workflows/pub.yaml
@@ -14,7 +14,7 @@ jobs:
         with:
           java-version: 1.8
       - name: Publish to the Maven Central Repository
-        run: ./gradlew publish -PcheckoutIfCloned -Prelease
+        run: ./gradlew :publish -Prelease
         env:
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           OSSRH_TOKEN: ${{ secrets.OSSRH_TOKEN }}

--- a/.github/workflows/release-ci.yaml
+++ b/.github/workflows/release-ci.yaml
@@ -16,4 +16,13 @@ jobs:
         with:
           java-version: 1.8
       - name: Build with Gradle
-        run: ./gradlew build -PcheckoutIfCloned -Prelease
+        run: ./gradlew :build -Prelease
+  android:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run tests on emulator
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 28
+          script: ./gradlew android-test:connectedAndroidTest -Prelease -Pandroid.useAndroidX=true --info

--- a/.github/workflows/scheduled-release-ci.yaml
+++ b/.github/workflows/scheduled-release-ci.yaml
@@ -17,4 +17,13 @@ jobs:
         with:
           java-version: 1.8
       - name: Build with Gradle
-        run: ./gradlew build -PcheckoutIfCloned -Prelease
+        run: ./gradlew :build -Prelease
+  android:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run tests on emulator
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 28
+          script: ./gradlew android-test:connectedAndroidTest -Prelease -Pandroid.useAndroidX=true --info

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 build/**
+android-test/build/**
 .gradle/**
 out/**
 .idea/**
 .composite-enable
 gradle.properties
+local.properties

--- a/android-test/build.gradle
+++ b/android-test/build.gradle
@@ -20,16 +20,38 @@ android {
         testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'
     }
 
+    // make the android-test subproject just reuse the math stuff
     sourceSets {
         main {
             java.srcDirs = ["../src/main/java"]
         }
 
-        androidTest {
-            setRoot '../src/test'
+        // unit tests. Run via test task
+        test {
+            java.srcDirs = ["../src/test/java"]
         }
     }
 
+    testOptions {
+        unitTests {
+            all {
+                useJUnitPlatform()
+                maxParallelForks 4
+                //we want display the following test events
+                testLogging {
+                    events "PASSED", "STARTED", "FAILED", "SKIPPED"
+                }
+                afterSuite { desc, result ->
+                    if (!desc.parent) { // will match the outermost suite
+                        def output = "Results: ${result.resultType} (${result.testCount} tests, ${result.successfulTestCount} successes, ${result.failedTestCount} failures, ${result.skippedTestCount} skipped)"
+                        def startItem = '|  ', endItem = '  |'
+                        def repeatLength = startItem.length() + output.length() + endItem.length()
+                        println('\n' + ('-' * repeatLength) + '\n' + startItem + output + endItem + '\n' + ('-' * repeatLength))
+                    }
+                }
+            }
+        }
+    }
 }
 
 repositories {
@@ -40,4 +62,15 @@ repositories {
 dependencies {
     implementation group: 'com.googlecode.json-simple', name: 'json-simple', version:'1.1'
     implementation group: 'org.reflections', name: 'reflections', version:'0.9.10'
+
+    // (Required) Writing and executing Unit Tests on the JUnit Platform
+    testImplementation "org.junit.jupiter:junit-jupiter-api:5.7.1"
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.7.1"
+
+    // (Optional) If you need "Parameterized Tests"
+    testImplementation "org.junit.jupiter:junit-jupiter-params:5.7.1"
+
+    // (Optional) If you also have JUnit 4-based tests
+    testImplementation "junit:junit:4.13"
+    testRuntimeOnly "org.junit.vintage:junit-vintage-engine:5.7.1"
 }

--- a/android-test/build.gradle
+++ b/android-test/build.gradle
@@ -1,0 +1,43 @@
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+    }
+
+    dependencies {
+        classpath 'com.android.tools.build:gradle:4.2.1'
+    }
+}
+
+apply plugin: 'com.android.library'
+
+android {
+    compileSdkVersion 30
+    defaultConfig {
+        minSdkVersion 28
+        targetSdkVersion 30
+
+        testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'
+    }
+
+    sourceSets {
+        main {
+            java.srcDirs = ["../src/main/java"]
+        }
+
+        androidTest {
+            setRoot '../src/test'
+        }
+    }
+
+}
+
+repositories {
+    mavenCentral()
+    google()
+}
+
+dependencies {
+    implementation group: 'com.googlecode.json-simple', name: 'json-simple', version:'1.1'
+    implementation group: 'org.reflections', name: 'reflections', version:'0.9.10'
+}

--- a/android-test/build.gradle
+++ b/android-test/build.gradle
@@ -6,10 +6,12 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:4.2.1'
+        classpath("de.mannodermaus.gradle.plugins:android-junit5:1.7.1.1")
     }
 }
 
 apply plugin: 'com.android.library'
+apply plugin: "de.mannodermaus.android-junit5"
 
 android {
     compileSdkVersion 30
@@ -17,7 +19,9 @@ android {
         minSdkVersion 28
         targetSdkVersion 30
 
-        testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'
+        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
+        // JUnit 5 support for instrumentation tests
+        testInstrumentationRunnerArgument "runnerBuilder", "de.mannodermaus.junit5.AndroidJUnit5Builder"
     }
 
     // make the android-test subproject just reuse the math stuff
@@ -30,6 +34,15 @@ android {
         test {
             java.srcDirs = ["../src/test/java"]
         }
+
+        androidTest {
+            java.srcDirs = ["../src/test/java"]
+        }
+    }
+
+    compileOptions {
+        setSourceCompatibility(JavaVersion.VERSION_1_8)
+        setTargetCompatibility(JavaVersion.VERSION_1_8)
     }
 
     testOptions {
@@ -73,4 +86,12 @@ dependencies {
     // (Optional) If you also have JUnit 4-based tests
     testImplementation "junit:junit:4.13"
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine:5.7.1"
+
+    // Instrumentation test stuff
+    androidTestImplementation "androidx.test:runner:1.3.0"
+    androidTestImplementation "org.junit.jupiter:junit-jupiter-api:5.7.1"
+    androidTestImplementation "org.junit.jupiter:junit-jupiter-params:5.7.1"
+
+    androidTestImplementation "de.mannodermaus.junit5:android-test-core:1.2.2"
+    androidTestRuntimeOnly "de.mannodermaus.junit5:android-test-runner:1.2.2"
 }

--- a/android-test/src/main/AndroidManifest.xml
+++ b/android-test/src/main/AndroidManifest.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="org.cryptimeleon.math">
+</manifest>

--- a/build.gradle
+++ b/build.gradle
@@ -9,19 +9,15 @@ archivesBaseName = project.name
 boolean isRelease = project.hasProperty("release")
 version = '2.0.0'  + (isRelease ? "" : "-SNAPSHOT")
 
-
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 tasks.withType(JavaCompile) {
 	options.encoding = 'UTF-8'
 }
 
-
-
 repositories {
     mavenLocal()
     mavenCentral()
-    jcenter()
 }
 
 dependencies {
@@ -43,7 +39,6 @@ dependencies {
             'org.junit.vintage:junit-vintage-engine:5.1.0'
     )
 }
-
 
 test {
     useJUnitPlatform()

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,3 @@
 rootProject.name = 'math'
+
+include 'android-test'

--- a/src/main/java/org/cryptimeleon/math/expressions/exponent/ExponentPowExpr.java
+++ b/src/main/java/org/cryptimeleon/math/expressions/exponent/ExponentPowExpr.java
@@ -2,6 +2,7 @@ package org.cryptimeleon.math.expressions.exponent;
 
 import org.cryptimeleon.math.expressions.Expression;
 import org.cryptimeleon.math.expressions.Substitution;
+import org.cryptimeleon.math.misc.BigIntegerTools;
 import org.cryptimeleon.math.structures.rings.zn.Zn;
 
 import java.math.BigInteger;
@@ -42,7 +43,9 @@ public class ExponentPowExpr implements ExponentExpr {
 
     @Override
     public BigInteger evaluate() {
-        return base.evaluate().pow(exponent.evaluate().intValueExact());
+        return base.evaluate().pow(
+                BigIntegerTools.getExactInt(exponent.evaluate())
+        );
     }
 
     @Override

--- a/src/main/java/org/cryptimeleon/math/misc/BigIntegerTools.java
+++ b/src/main/java/org/cryptimeleon/math/misc/BigIntegerTools.java
@@ -1,0 +1,23 @@
+package org.cryptimeleon.math.misc;
+
+import java.math.BigInteger;
+
+public abstract class BigIntegerTools {
+
+    /**
+     * Returns the integer value corresponding to the given {@link BigInteger}, throwing a {@link ArithmeticException}
+     * if the value is out of bounds.
+     * <p>
+     * Implements the {@code intValueExact} method of {@code BigInteger} that is missing in the Android Sdk.
+     * @param num the {@code BigInteger} to convert
+     * @return the integer with the same value as {@code num}
+     *
+     * @throws ArithmeticException if the value of {@code num} is outside the supported integer values
+     */
+    public static Integer getExactInt(BigInteger num) {
+        if (num.compareTo(BigInteger.valueOf(Integer.MAX_VALUE)) > 0
+                || num.compareTo(BigInteger.valueOf(Integer.MIN_VALUE)) < 0)
+            throw new ArithmeticException("Integer value of BigInteger " + num + " is out of integer range");
+        return num.intValue();
+    }
+}

--- a/src/main/java/org/cryptimeleon/math/serialization/annotations/StandaloneRepresentationHandler.java
+++ b/src/main/java/org/cryptimeleon/math/serialization/annotations/StandaloneRepresentationHandler.java
@@ -63,7 +63,11 @@ class StandaloneRepresentationHandler implements RepresentationHandler {
         }
 
         if (type.isAssignableFrom(Integer.class) && repr instanceof BigIntegerRepresentation) {
-            return repr.bigInt().get().intValue();
+            BigInteger value = repr.bigInt().get();
+            if (value.compareTo(BigInteger.valueOf(Integer.MAX_VALUE)) > 0 
+                    || value.compareTo(BigInteger.valueOf(Integer.MIN_VALUE)) < 0)
+                throw new ArithmeticException("Integer value of BigInteger " + value + " is out of integer range");
+            return value.intValue();
         }
 
         if (type.isAssignableFrom(String.class) && repr instanceof StringRepresentation) {

--- a/src/main/java/org/cryptimeleon/math/serialization/annotations/StandaloneRepresentationHandler.java
+++ b/src/main/java/org/cryptimeleon/math/serialization/annotations/StandaloneRepresentationHandler.java
@@ -63,7 +63,7 @@ class StandaloneRepresentationHandler implements RepresentationHandler {
         }
 
         if (type.isAssignableFrom(Integer.class) && repr instanceof BigIntegerRepresentation) {
-            return repr.bigInt().get().intValueExact();
+            return repr.bigInt().get().intValue();
         }
 
         if (type.isAssignableFrom(String.class) && repr instanceof StringRepresentation) {

--- a/src/main/java/org/cryptimeleon/math/serialization/annotations/StandaloneRepresentationHandler.java
+++ b/src/main/java/org/cryptimeleon/math/serialization/annotations/StandaloneRepresentationHandler.java
@@ -1,5 +1,6 @@
 package org.cryptimeleon.math.serialization.annotations;
 
+import org.cryptimeleon.math.misc.BigIntegerTools;
 import org.cryptimeleon.math.serialization.*;
 
 import java.lang.reflect.Type;
@@ -63,11 +64,7 @@ class StandaloneRepresentationHandler implements RepresentationHandler {
         }
 
         if (type.isAssignableFrom(Integer.class) && repr instanceof BigIntegerRepresentation) {
-            BigInteger value = repr.bigInt().get();
-            if (value.compareTo(BigInteger.valueOf(Integer.MAX_VALUE)) > 0 
-                    || value.compareTo(BigInteger.valueOf(Integer.MIN_VALUE)) < 0)
-                throw new ArithmeticException("Integer value of BigInteger " + value + " is out of integer range");
-            return value.intValue();
+            return BigIntegerTools.getExactInt(repr.bigInt().get());
         }
 
         if (type.isAssignableFrom(String.class) && repr instanceof StringRepresentation) {

--- a/src/main/java/org/cryptimeleon/math/serialization/converter/BinaryFormatConverter.java
+++ b/src/main/java/org/cryptimeleon/math/serialization/converter/BinaryFormatConverter.java
@@ -1,5 +1,6 @@
 package org.cryptimeleon.math.serialization.converter;
 
+import org.cryptimeleon.math.misc.BigIntegerTools;
 import org.cryptimeleon.math.serialization.*;
 
 import java.math.BigInteger;
@@ -114,7 +115,7 @@ public class BinaryFormatConverter extends Converter<byte[]> {
             // Format: type(1) || int(4) for 32 bit integers, and type(1) || ptr(4) for long integers.
             BigInteger value = repr.bigInt().get();
             try {
-                int valueAsInlineInt = value.intValueExact();
+                int valueAsInlineInt = BigIntegerTools.getExactInt(value);
                 structure.append(TYPE_INT_INLINE);
                 structure.append(valueAsInlineInt);
             } catch (ArithmeticException e) {

--- a/src/main/java/org/cryptimeleon/math/structures/rings/extfield/ExtensionField.java
+++ b/src/main/java/org/cryptimeleon/math/structures/rings/extfield/ExtensionField.java
@@ -1,5 +1,6 @@
 package org.cryptimeleon.math.structures.rings.extfield;
 
+import org.cryptimeleon.math.misc.BigIntegerTools;
 import org.cryptimeleon.math.serialization.*;
 import org.cryptimeleon.math.structures.rings.Field;
 import org.cryptimeleon.math.structures.rings.FieldElement;
@@ -103,7 +104,10 @@ public class ExtensionField implements Field {
         Field baseField = (Field) ((RepresentableRepresentation) o.get("baseField")).recreateRepresentable();
 
 
-        init(baseField.restoreElement(o.get("constant")), o.get("extensionDegree").bigInt().get().intValueExact());
+        init(baseField.restoreElement(
+                o.get("constant")),
+                BigIntegerTools.getExactInt(o.get("extensionDegree").bigInt().get())
+        );
 
         if (o.get("cubeRoot") != null)
             this.setCubeRoot(this.restoreElement(o.get("cubeRoot")));

--- a/src/test/java/org/cryptimeleon/math/serialization/standalone/StandaloneReprSubTest.java
+++ b/src/test/java/org/cryptimeleon/math/serialization/standalone/StandaloneReprSubTest.java
@@ -26,7 +26,6 @@ public abstract class StandaloneReprSubTest {
     protected final void test(StandaloneRepresentable object) {
         Class<? extends StandaloneRepresentable> clazz = object.getClass();
         testedClasses.add(clazz);
-
         //Test for constructor with single Representation parameter
         try {
             Constructor<? extends StandaloneRepresentable> constructor = clazz.getConstructor(Representation.class);


### PR DESCRIPTION
**Reason for this PR:**

- We use `BigInteger:intValueExact()` which is [not supported by Android Version < S](https://developer.android.com/reference/java/math/BigInteger#intValueExact()) 
- To avoid future compatibility issues, we would like to include Android testing into the testing workflows

**Changes in this PR:**
 - Use `BigInteger:intValue()` plus some additional checks to emulate the behavior of `intValueExact()`
 - Add Github actions job to run Math tests on Android emulator. This is implemented via an Android subproject that has the math root source set configured as its own source set and is therefore able to run the Math tests.
