### PR TITLE
Move prf stuff over from craco

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `BasicBilinearGroup` wrappers for the implemented bilinear groups
 - Convenience methods for the vector classes
 - `square`, `div` and `valueOf` convenience methods for `Zn` and `Zp` classes
+- PRF classes from Craco now are part of Math
+- `ByteArrayImpl`, a byte array implementation
 
 ### Changed
 - Renamed "counting" group classes and package to "debug"

--- a/src/main/java/org/cryptimeleon/math/misc/ByteArrayImpl.java
+++ b/src/main/java/org/cryptimeleon/math/misc/ByteArrayImpl.java
@@ -1,0 +1,134 @@
+package org.cryptimeleon.math.misc;
+
+import org.cryptimeleon.math.hash.ByteAccumulator;
+import org.cryptimeleon.math.prf.PrfImage;
+import org.cryptimeleon.math.prf.PrfKey;
+import org.cryptimeleon.math.prf.PrfPreimage;
+import org.cryptimeleon.math.random.RandomGenerator;
+import org.cryptimeleon.math.serialization.Representation;
+import org.cryptimeleon.math.serialization.annotations.ReprUtil;
+import org.cryptimeleon.math.serialization.annotations.Represented;
+
+import java.util.Arrays;
+
+public class ByteArrayImpl implements PrfKey, PrfPreimage, PrfImage {
+
+    @Represented
+    protected byte[] data;
+
+    public ByteArrayImpl(byte[] bytes) {
+        this.data = bytes;
+    }
+
+    public ByteArrayImpl(Representation repr) {
+        new ReprUtil(this).deserialize(repr);
+    }
+
+    /**
+     * Creates a new {@code ByteArrayImpl} instance filled with {@code numberBytes} bytes of randomness
+     *
+     * @param numberBytes number of random bytes / length of resulting ByteArrayImplementation
+     */
+    public static ByteArrayImpl fromRandom(int numberBytes) {
+        return new ByteArrayImpl(RandomGenerator.getRandomBytes(numberBytes));
+    }
+
+    public byte[] getData() {
+        return data;
+    }
+
+    /**
+     * Create new byte array as concatenation of {@code this} with {@code a}.
+     *
+     * @param a the array to append
+     * @return the result of concatenation
+     */
+    public ByteArrayImpl append(ByteArrayImpl a) {
+        byte[] result = new byte[data.length + a.getData().length];
+        System.arraycopy(data, 0, result, 0, data.length);
+        System.arraycopy(a.data, 0, result, data.length, a.getData().length);
+        return new ByteArrayImpl(result);
+    }
+
+    /**
+     * Returns an array containing the designated part of this byte array, meaning that
+     * {@code returned[i] = this[firstIndex+i]}.
+     * @param firstIndex first (byte) index that will be copied to the result
+     * @param length the number of bytes to be copied
+     * @return a {@linkplain ByteArrayImpl} of length {@code length} that is a substring of this original.
+     */
+    public ByteArrayImpl substring(int firstIndex, int length) {
+        byte[] result = new byte[length];
+        System.arraycopy(data, firstIndex, result, 0, length);
+        return new ByteArrayImpl(result);
+    }
+
+    /**
+     * Returns the length of this byte array.
+     *
+     * @return the length of this byte array
+     */
+    public int length() {
+        return data.length;
+    }
+
+    /**
+     * Compute exclusive or of two byte arrays.
+     * <p>
+     * Returns a new byte array where the i-th entry is the exclusive or of {@code this}
+     * byte array's i-th entry and {@code a}'s i-th entry.
+     *
+     * @param a the argument to XOR {@code this} with
+     * @return the result of XORing
+     */
+    public ByteArrayImpl xor(ByteArrayImpl a) {
+        int min = Math.min(this.length(), a.length());
+        int max = Math.max(this.length(), a.length());
+
+        byte[] result = new byte[max];
+        for (int i = 0; i < min; i++) {
+            result[i] = (byte) (this.getData()[i] ^ a.getData()[i]);
+        }
+        return new ByteArrayImpl(result);
+    }
+
+    @Override
+    public Representation getRepresentation() {
+        return ReprUtil.serialize(this);
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(data);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        ByteArrayImpl other = (ByteArrayImpl) obj;
+        return Arrays.equals(data, other.data);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder result = new StringBuilder("[");
+        for (int i = 0; i < this.getData().length; i++) {
+            result.append(String.format("%d", Byte.toUnsignedInt(this.getData()[i])));
+            if (i < this.getData().length - 1)
+                result.append(",");
+        }
+        result.append("]");
+        return result.toString();
+    }
+
+    @Override
+    public ByteAccumulator updateAccumulator(ByteAccumulator accumulator) {
+        accumulator.append(data);
+        return accumulator;
+    }
+}

--- a/src/main/java/org/cryptimeleon/math/prf/PrfImage.java
+++ b/src/main/java/org/cryptimeleon/math/prf/PrfImage.java
@@ -1,0 +1,11 @@
+package org.cryptimeleon.math.prf;
+
+import org.cryptimeleon.math.hash.UniqueByteRepresentable;
+import org.cryptimeleon.math.serialization.Representable;
+
+/**
+ * Output of a {@link PseudorandomFunction}.
+ */
+public interface PrfImage extends Representable, UniqueByteRepresentable {
+
+}

--- a/src/main/java/org/cryptimeleon/math/prf/PrfKey.java
+++ b/src/main/java/org/cryptimeleon/math/prf/PrfKey.java
@@ -1,0 +1,12 @@
+package org.cryptimeleon.math.prf;
+
+import org.cryptimeleon.math.hash.UniqueByteRepresentable;
+import org.cryptimeleon.math.serialization.Representable;
+
+
+/**
+ * Key used to parameterize a {@link PseudorandomFunction}.
+ */
+public interface PrfKey extends Representable, UniqueByteRepresentable {
+
+}

--- a/src/main/java/org/cryptimeleon/math/prf/PrfPreimage.java
+++ b/src/main/java/org/cryptimeleon/math/prf/PrfPreimage.java
@@ -1,0 +1,12 @@
+package org.cryptimeleon.math.prf;
+
+import org.cryptimeleon.math.hash.UniqueByteRepresentable;
+import org.cryptimeleon.math.serialization.Representable;
+
+
+/**
+ * Input for a {@link PseudorandomFunction}.
+ */
+public interface PrfPreimage extends Representable, UniqueByteRepresentable {
+
+}

--- a/src/main/java/org/cryptimeleon/math/prf/PseudorandomFunction.java
+++ b/src/main/java/org/cryptimeleon/math/prf/PseudorandomFunction.java
@@ -1,0 +1,65 @@
+package org.cryptimeleon.math.prf;
+
+import org.cryptimeleon.math.prf.PrfImage;
+import org.cryptimeleon.math.prf.PrfKey;
+import org.cryptimeleon.math.prf.PrfPreimage;
+import org.cryptimeleon.math.serialization.Representation;
+import org.cryptimeleon.math.serialization.StandaloneRepresentable;
+import org.cryptimeleon.math.serialization.annotations.RepresentationRestorer;
+
+import java.lang.reflect.Type;
+
+/**
+ * A pseudorandom function is a family of functions \((f_k)\)
+ * so that for random choice of the key k, \(f_k: X \rightarrow Y\) is computationally
+ * indistinguishable from a uniformly random function \(F: X \rightarrow Y\).
+ * <p>
+ * The way to use this interface is:
+ * <ol>
+ * <li> Generate a key k using {@link #generateKey()}
+ * <li> Call {@link #evaluate(PrfKey, PrfPreimage)} using key k and input x to receive \(y = f_k(x)\)
+ * </ol>
+ */
+public interface PseudorandomFunction extends StandaloneRepresentable, RepresentationRestorer {
+    /**
+     * Generates a key k for use with this PRF.
+     */
+    PrfKey generateKey();
+
+    /**
+     * Maps a preimage x to its image using key k.
+     *
+     * @return output of \(f_k(x)\)
+     */
+    PrfImage evaluate(PrfKey k, PrfPreimage x);
+
+    //below this, there are only serialization-related methods
+
+    /**
+     * Restores a key k from its representation.
+     */
+    PrfKey restoreKey(Representation repr);
+
+    /**
+     * Restores a preimage x from its representation.
+     */
+    PrfPreimage restorePreimage(Representation repr);
+
+    /**
+     * Restores an image y from its representation.
+     */
+    PrfImage restoreImage(Representation repr);
+
+    default Object restoreFromRepresentation(Type type, Representation repr) {
+        if (type instanceof Class) {
+            if (PrfKey.class.isAssignableFrom((Class) type)) {
+                return this.restoreKey(repr);
+            } else if (PrfPreimage.class.isAssignableFrom((Class) type)) {
+                return this.restorePreimage(repr);
+            } else if (PrfImage.class.isAssignableFrom((Class) type)) {
+                return this.restoreImage(repr);
+            }
+        }
+        throw new IllegalArgumentException("Cannot restore object of type: " + type.getTypeName());
+    }
+}

--- a/src/main/java/org/cryptimeleon/math/prf/aes/AesPseudorandomFunction.java
+++ b/src/main/java/org/cryptimeleon/math/prf/aes/AesPseudorandomFunction.java
@@ -1,0 +1,111 @@
+package org.cryptimeleon.math.prf.aes;
+
+import org.cryptimeleon.math.misc.ByteArrayImpl;
+import org.cryptimeleon.math.prf.PrfImage;
+import org.cryptimeleon.math.prf.PrfKey;
+import org.cryptimeleon.math.prf.PrfPreimage;
+import org.cryptimeleon.math.prf.PseudorandomFunction;
+import org.cryptimeleon.math.serialization.Representation;
+import org.cryptimeleon.math.serialization.annotations.ReprUtil;
+import org.cryptimeleon.math.serialization.annotations.Represented;
+
+import javax.crypto.BadPaddingException;
+import javax.crypto.Cipher;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.NoSuchPaddingException;
+import javax.crypto.spec.SecretKeySpec;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Objects;
+
+/**
+ * AES as a pseudorandom function (permutation) \(f_k : \{0,1\}^l \rightarrow \{0,1\}^l\)
+ * for \(k \in \{0,1\}^l\). Here, l is any valid AES keylength (e.g., 128, 256).
+ * <p>
+ * {@link PrfKey}, {@link PrfPreimage}, and  {@link PrfImage} are of type {@link ByteArrayImpl}.
+ */
+public class AesPseudorandomFunction implements PseudorandomFunction {
+    @Represented
+    protected Integer keylength; //length of keys in bit
+
+    /**
+     * Instantiates the PRF with a given AES key length.
+     *
+     * @param keylength a valid AES key length in bit (e.g., 128 or 256)
+     */
+    public AesPseudorandomFunction(int keylength) {
+        this.keylength = keylength;
+    }
+
+    public AesPseudorandomFunction(Representation repr) {
+        new ReprUtil(this).deserialize(repr);
+    }
+
+    @Override
+    public Representation getRepresentation() {
+        return ReprUtil.serialize(this);
+    }
+
+    @Override
+    public PrfKey generateKey() {
+        return ByteArrayImpl.fromRandom(keylength / 8);
+    }
+
+    @Override
+    public PrfImage evaluate(PrfKey k, PrfPreimage x) {
+        if (((ByteArrayImpl) k).length() != keylength / 8)
+            throw new IllegalArgumentException("key k in the AES PRF has invalid length");
+        if (((ByteArrayImpl) x).length() != keylength / 8)
+            throw new IllegalArgumentException("preimage x in the AES PRF has invalid length");
+
+        try {
+            Cipher cipher = Cipher.getInstance("AES/ECB/NoPadding");
+            SecretKeySpec keySpec = new SecretKeySpec(((ByteArrayImpl) k).getData(), "AES");
+            cipher.init(Cipher.ENCRYPT_MODE, keySpec);
+            return new ByteArrayImpl(cipher.doFinal(((ByteArrayImpl) x).getData()));
+        } catch (NoSuchAlgorithmException | NoSuchPaddingException | BadPaddingException e) {
+            e.printStackTrace();
+            throw new RuntimeException(e);
+        } catch (InvalidKeyException e) {
+            e.printStackTrace();
+            throw new IllegalArgumentException("Input k to AES PRF must be of valid AES key length");
+        } catch (IllegalBlockSizeException e) {
+            e.printStackTrace();
+            throw new IllegalArgumentException("Input x to AES PRF must be of valid AES key length");
+        }
+    }
+
+    @Override
+    public PrfKey restoreKey(Representation repr) {
+        return new ByteArrayImpl(repr);
+    }
+
+    @Override
+    public PrfPreimage restorePreimage(Representation repr) {
+        return new ByteArrayImpl(repr);
+    }
+
+    @Override
+    public PrfImage restoreImage(Representation repr) {
+        return new ByteArrayImpl(repr);
+    }
+
+    @Override
+    public int hashCode() {
+        return keylength;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        AesPseudorandomFunction other = (AesPseudorandomFunction) o;
+        return Objects.equals(keylength, other.keylength);
+    }
+
+    public Integer getKeylength() {
+        return keylength;
+    }
+}

--- a/src/main/java/org/cryptimeleon/math/prf/aes/LongAesPseudoRandomFunction.java
+++ b/src/main/java/org/cryptimeleon/math/prf/aes/LongAesPseudoRandomFunction.java
@@ -1,10 +1,9 @@
-package org.cryptimeleon.math.prf.zn;
+package org.cryptimeleon.math.prf.aes;
 
 import org.cryptimeleon.math.misc.ByteArrayImpl;
 import org.cryptimeleon.math.prf.PrfKey;
 import org.cryptimeleon.math.prf.PrfPreimage;
 import org.cryptimeleon.math.prf.PseudorandomFunction;
-import org.cryptimeleon.math.prf.aes.AesPseudorandomFunction;
 import org.cryptimeleon.math.serialization.Representation;
 import org.cryptimeleon.math.serialization.annotations.ReprUtil;
 import org.cryptimeleon.math.serialization.annotations.Represented;

--- a/src/main/java/org/cryptimeleon/math/prf/aes/package-info.java
+++ b/src/main/java/org/cryptimeleon/math/prf/aes/package-info.java
@@ -1,4 +1,4 @@
 /**
  * Contains an implementation of an AES-based pseudorandom function.
  */
-package org.cryptimeleon.craco.prf.aes;
+package org.cryptimeleon.math.prf.aes;

--- a/src/main/java/org/cryptimeleon/math/prf/aes/package-info.java
+++ b/src/main/java/org/cryptimeleon/math/prf/aes/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Contains an implementation of an AES-based pseudorandom function.
+ */
+package org.cryptimeleon.craco.prf.aes;

--- a/src/main/java/org/cryptimeleon/math/prf/package-info.java
+++ b/src/main/java/org/cryptimeleon/math/prf/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Contains basic interfaces related to pseudorandom functions.
+ */
+package org.cryptimeleon.craco.prf;

--- a/src/main/java/org/cryptimeleon/math/prf/package-info.java
+++ b/src/main/java/org/cryptimeleon/math/prf/package-info.java
@@ -1,4 +1,4 @@
 /**
  * Contains basic interfaces related to pseudorandom functions.
  */
-package org.cryptimeleon.craco.prf;
+package org.cryptimeleon.math.prf;

--- a/src/main/java/org/cryptimeleon/math/prf/zn/HashThenPrfToZn.java
+++ b/src/main/java/org/cryptimeleon/math/prf/zn/HashThenPrfToZn.java
@@ -6,6 +6,7 @@ import org.cryptimeleon.math.hash.impl.ByteArrayAccumulator;
 import org.cryptimeleon.math.misc.ByteArrayImpl;
 import org.cryptimeleon.math.prf.PrfKey;
 import org.cryptimeleon.math.prf.aes.AesPseudorandomFunction;
+import org.cryptimeleon.math.prf.aes.LongAesPseudoRandomFunction;
 import org.cryptimeleon.math.serialization.Representation;
 import org.cryptimeleon.math.serialization.StandaloneRepresentable;
 import org.cryptimeleon.math.serialization.annotations.ReprUtil;

--- a/src/main/java/org/cryptimeleon/math/prf/zn/HashThenPrfToZn.java
+++ b/src/main/java/org/cryptimeleon/math/prf/zn/HashThenPrfToZn.java
@@ -1,0 +1,200 @@
+package org.cryptimeleon.math.prf.zn;
+
+import org.cryptimeleon.math.hash.HashFunction;
+import org.cryptimeleon.math.hash.UniqueByteRepresentable;
+import org.cryptimeleon.math.hash.impl.ByteArrayAccumulator;
+import org.cryptimeleon.math.misc.ByteArrayImpl;
+import org.cryptimeleon.math.prf.PrfKey;
+import org.cryptimeleon.math.prf.aes.AesPseudorandomFunction;
+import org.cryptimeleon.math.serialization.Representation;
+import org.cryptimeleon.math.serialization.StandaloneRepresentable;
+import org.cryptimeleon.math.serialization.annotations.ReprUtil;
+import org.cryptimeleon.math.serialization.annotations.Represented;
+import org.cryptimeleon.math.structures.rings.RingElement;
+import org.cryptimeleon.math.structures.rings.cartesian.RingElementVector;
+import org.cryptimeleon.math.structures.rings.zn.Zn;
+
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.Objects;
+
+/**
+ * Get pseudorandom Zn Elements by a hash-then-prf construction.
+ * <p>
+ * We use a PRF that outputs bitstrings and map these to Zp as follows:
+ * We divide the output interval of size 2^n (with elements in [0,2^n-1]) into a 'good' and a 'bad' interval, where the
+ * good interval is [0,x*p[ with x*p{@literal <}2^n chosen to be maximal and the bad interval [x*p,2^n-1].
+ * Since x is maximal, the bad interval has size at most p-1.
+ * <p>
+ * To get a ZnElement, we hash, use the PRF and get some output value o.
+ * If o is in the good interval, we output o mod p
+ * as our ZnElement. This is random for random bit strings, since the good interval's size is a multiple of p.
+ * If o is in the bad interval, we reject and throw an exception. We don't want this to happen, hence we increase the
+ * good interval by using a longer PRF, this can be influenced by the so called 'oversubscription'. Since the bad
+ * interval's size is bound by p, increasing the total interval reduces the probability of landing in the bad interval.
+ * More precisely, the reject rate is bound by (1/2)^oversubscription.
+ */
+public class HashThenPrfToZn implements StandaloneRepresentable {
+    @Represented
+    private LongAesPseudoRandomFunction longAesPseudoRandomFunction;
+    @Represented
+    private HashFunction hashFunction;
+    @Represented
+    private Zn zn;
+
+    // Redundant parameter that we do not want to compute every time we use this
+    private BigInteger maxQuotient; // x from the description
+
+    /**
+     * Instantiate HashThenPrfToZn
+     *
+     * @param aesKeyLength     bit length of AES
+     * @param zn               target ring
+     * @param hashFunction     hash function to use, output size should be larger than AES input size
+     * @param oversubscription parameter that binds the probability of failing by (1/2)^oversubscription. Probability can be lower due to rounding
+     */
+    public HashThenPrfToZn(int aesKeyLength, Zn zn, HashFunction hashFunction, int oversubscription) {
+        if (hashFunction.getOutputLength() * 8 < aesKeyLength) {
+            throw new IllegalArgumentException("Hash function output should be larger or equal to AES input size.");
+        }
+
+        this.hashFunction = hashFunction;
+        this.zn = zn;
+        this.longAesPseudoRandomFunction = new LongAesPseudoRandomFunction(
+                new AesPseudorandomFunction(aesKeyLength),
+                (zn.getCharacteristic().bitLength() + aesKeyLength + oversubscription + 1) / aesKeyLength  // Compute number of AES instances required to get desired output bit length
+        );
+        this.init();
+    }
+
+    public HashThenPrfToZn(Representation repr) {
+        new ReprUtil(this).deserialize(repr);
+        this.init();
+    }
+
+    /**
+     * Initialization of HashTHenPrfToZn.
+     */
+    private void init() {
+        BigInteger p = zn.getCharacteristic();
+
+        // Compute quotient of prf output all 1s divided by p
+        // We can use all remainders with quotients strictly smaller than that quotient to draw uniformly at random from Zp
+        byte[] bytes = new byte[longAesPseudoRandomFunction.getKeyLengthBytes()];
+        Arrays.fill(bytes, (byte) 255);
+
+        BigInteger[] dar = new BigInteger(1, bytes).divideAndRemainder(p);
+        this.maxQuotient = dar[0];
+    }
+
+    /**
+     * Generates a PRF key that can be used to hash-then-prf to Zn
+     *
+     * @return a PRF key
+     */
+    public PrfKey generateKey() {
+        return longAesPseudoRandomFunction.generateKey();
+    }
+
+
+    /**
+     * Generate pseudorandom ZnVectors of variable size using unique prefixes for the vectorSize and index.
+     *
+     * @param prfKey     the PRF key
+     * @param hashInput  input to hash
+     * @param vectorSize target vector size
+     * @param prefix     prefix to allow using the same vectorSize and preImage several times
+     * @return a pseudorandom Vector of Zn elements
+     */
+    public RingElementVector hashThenPrfToZnVector(PrfKey prfKey, UniqueByteRepresentable hashInput, int vectorSize, String prefix) {
+        RingElement[] result = new RingElement[vectorSize];
+
+        for (int i = 0; i < vectorSize; i++) {
+            ByteArrayAccumulator accumulator = new ByteArrayAccumulator();
+            accumulator.append(vectorSize); // Ensure uniqueness for each vector size, allows using the same preimage for several, different sized vectors
+            accumulator.append(i); // Index to prevent having the same output for each element
+            accumulator.escapeAndSeparate(prefix); // Prefix to allow using the same preImage and vectorSize twice
+            accumulator.escapeAndAppend(hashInput);
+            Zn.ZnElement element = hashThenPrfToZn(prfKey, accumulator.extractBytes());
+            result[i] = element;
+        }
+
+        return new RingElementVector(result);
+    }
+
+    /**
+     * Main method of Hash-then-PRF to Zn.
+     * Private to avoid accidentally mixing different hashInput formats.
+     *
+     * @param prfKey    the PRF key
+     * @param hashInput input to hash
+     * @return a pseudorandom Zn element
+     */
+    private Zn.ZnElement hashThenPrfToZn(PrfKey prfKey, byte[] hashInput) {
+        BigInteger p = zn.getCharacteristic();
+
+        // Compute hash value
+        byte[] hashOutput = hashFunction.hash(hashInput);
+
+        // Truncate hash
+        byte[] prfInput = new byte[longAesPseudoRandomFunction.getPreimageLengthBytes()];
+        System.arraycopy(hashOutput, 0, prfInput, 0, longAesPseudoRandomFunction.getPreimageLengthBytes());
+
+        // Compute prf(hash)
+        ByteArrayImpl prfOutput = longAesPseudoRandomFunction.evaluate(prfKey, new ByteArrayImpl(prfInput));
+
+        //Compute quotient and remainder of the prf output interpreted as a positive integer. Return remainder as
+        // ZnElement if quotient is smaller than largest quotient to ensurer elements are drawn uniformly at random
+        // from Zn
+        BigInteger[] quotientAndRemainder = new BigInteger(1, prfOutput.getData()).divideAndRemainder(p);
+
+        if (quotientAndRemainder[0].compareTo(maxQuotient) >= 0) {
+            throw new RuntimeException("PRF output is in the reject interval!");
+        }
+
+        return zn.valueOf(quotientAndRemainder[1]);
+    }
+
+    /*
+     * Some wrappers with different method signatures.
+     */
+
+    public RingElementVector hashThenPrfToZnVector(PrfKey prfKey, UniqueByteRepresentable hashInput, int vectorSize) {
+        return hashThenPrfToZnVector(prfKey, hashInput, vectorSize, "");
+    }
+
+    public Zn.ZnElement hashThenPrfToZn(PrfKey prfKey, UniqueByteRepresentable hashInput) {
+        return (Zn.ZnElement) hashThenPrfToZnVector(prfKey, hashInput, 1, "").get(0);
+    }
+
+    public Zn.ZnElement hashThenPrfToZn(PrfKey prfKey, UniqueByteRepresentable hashInput, String prefix) {
+        return (Zn.ZnElement) hashThenPrfToZnVector(prfKey, hashInput, 1, prefix).get(0);
+    }
+
+
+    public LongAesPseudoRandomFunction getLongAesPseudoRandomFunction() {
+        return longAesPseudoRandomFunction;
+    }
+
+    public HashFunction getHashFunction() {
+        return hashFunction;
+    }
+
+    @Override
+    public Representation getRepresentation() {
+        return ReprUtil.serialize(this);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        HashThenPrfToZn prfToZn = (HashThenPrfToZn) o;
+        return Objects.equals(longAesPseudoRandomFunction, prfToZn.longAesPseudoRandomFunction) && Objects.equals(hashFunction, prfToZn.hashFunction) && Objects.equals(zn, prfToZn.zn) && Objects.equals(maxQuotient, prfToZn.maxQuotient);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(longAesPseudoRandomFunction, hashFunction, zn, maxQuotient);
+    }
+}

--- a/src/main/java/org/cryptimeleon/math/prf/zn/LongAesPseudoRandomFunction.java
+++ b/src/main/java/org/cryptimeleon/math/prf/zn/LongAesPseudoRandomFunction.java
@@ -1,0 +1,113 @@
+package org.cryptimeleon.math.prf.zn;
+
+import org.cryptimeleon.math.misc.ByteArrayImpl;
+import org.cryptimeleon.math.prf.PrfKey;
+import org.cryptimeleon.math.prf.PrfPreimage;
+import org.cryptimeleon.math.prf.PseudorandomFunction;
+import org.cryptimeleon.math.prf.aes.AesPseudorandomFunction;
+import org.cryptimeleon.math.serialization.Representation;
+import org.cryptimeleon.math.serialization.annotations.ReprUtil;
+import org.cryptimeleon.math.serialization.annotations.Represented;
+
+import java.util.Objects;
+
+/**
+ * AES based PRF with k key length and output length of the underlying AES key length.
+ * PRF_k(x) = AES_k1(x)||AES_k2(x)|..." with key k=(k1,k2,...)
+ * <p>
+ * This is basically a wrapper around AesPseudorandomFunction.
+ **/
+public class LongAesPseudoRandomFunction implements PseudorandomFunction {
+
+    @Represented
+    private AesPseudorandomFunction aesPseudorandomFunction;
+    @Represented
+    private Integer factor;
+    private int preimageLengthBytes;
+    private int keyLengthBytes;
+
+    /**
+     * Instantiates the PRF with an AES instance and desired factor.
+     *
+     * @param k                       factor by which output and key size of AES is increased
+     * @param aesPseudorandomFunction AES instance to use k times
+     */
+    public LongAesPseudoRandomFunction(AesPseudorandomFunction aesPseudorandomFunction, int k) {
+        this.aesPseudorandomFunction = aesPseudorandomFunction;
+        this.factor = k;
+        this.init();
+    }
+
+    public LongAesPseudoRandomFunction(Representation repr) {
+        new ReprUtil(this).deserialize(repr);
+        this.init();
+    }
+
+    private void init() {
+        this.preimageLengthBytes = aesPseudorandomFunction.getKeylength() / 8;
+        this.keyLengthBytes = preimageLengthBytes * factor;
+    }
+
+    @Override
+    public ByteArrayImpl generateKey() {
+        return ByteArrayImpl.fromRandom(keyLengthBytes);
+    }
+
+    @Override
+    public ByteArrayImpl evaluate(PrfKey k, PrfPreimage x) {
+        if (((ByteArrayImpl) k).length() != keyLengthBytes)
+            throw new IllegalArgumentException("key k in the AES PRF has invalid length");
+        if (((ByteArrayImpl) x).length() != preimageLengthBytes)
+            throw new IllegalArgumentException("preimage x in the AES PRF has invalid length");
+
+        ByteArrayImpl result = new ByteArrayImpl(new byte[0]);
+        for (int i = 0; i < factor; i++) {
+            ByteArrayImpl ki = ((ByteArrayImpl) k).substring(i * preimageLengthBytes, preimageLengthBytes);
+            byte[] bytesToAppend = ((ByteArrayImpl) aesPseudorandomFunction.evaluate(ki, x)).getData();
+            result = result.append(new ByteArrayImpl(bytesToAppend));
+        }
+        return result;
+    }
+
+
+    @Override
+    public ByteArrayImpl restoreKey(Representation repr) {
+        return new ByteArrayImpl(repr);
+    }
+
+    @Override
+    public ByteArrayImpl restorePreimage(Representation repr) {
+        return new ByteArrayImpl(repr);
+    }
+
+    @Override
+    public ByteArrayImpl restoreImage(Representation repr) {
+        return new ByteArrayImpl(repr);
+    }
+
+    @Override
+    public Representation getRepresentation() {
+        return ReprUtil.serialize(this);
+    }
+
+    public int getPreimageLengthBytes() {
+        return preimageLengthBytes;
+    }
+
+    public int getKeyLengthBytes() {
+        return keyLengthBytes;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        LongAesPseudoRandomFunction that = (LongAesPseudoRandomFunction) o;
+        return factor.equals(that.factor) && Objects.equals(aesPseudorandomFunction, that.aesPseudorandomFunction);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(aesPseudorandomFunction, factor);
+    }
+}

--- a/src/main/java/org/cryptimeleon/math/prf/zn/package-info.java
+++ b/src/main/java/org/cryptimeleon/math/prf/zn/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Contains an implementation of a Hash-then-Prf-to-Zn construction.
+ */
+package org.cryptimeleon.math.prf.zn;

--- a/src/test/java/org/cryptimeleon/math/prf/HashThenPrfTest.java
+++ b/src/test/java/org/cryptimeleon/math/prf/HashThenPrfTest.java
@@ -1,0 +1,105 @@
+package org.cryptimeleon.math.prf;
+
+import org.cryptimeleon.math.hash.HashFunction;
+import org.cryptimeleon.math.hash.UniqueByteRepresentable;
+import org.cryptimeleon.math.hash.impl.SHA256HashFunction;
+import org.cryptimeleon.math.hash.impl.SHA512HashFunction;
+import org.cryptimeleon.math.misc.ByteArrayImpl;
+import org.cryptimeleon.math.prf.zn.HashThenPrfToZn;
+import org.cryptimeleon.math.structures.rings.zn.Zn;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Random;
+import java.util.function.Supplier;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests the hash-then-prf-to-Zn construction.
+ */
+@RunWith(Parameterized.class)
+public class HashThenPrfTest {
+    private HashThenPrfToZn hashThenPrfToZn;
+    private Supplier<UniqueByteRepresentable> hashPreimageSupplier;
+
+
+    public HashThenPrfTest(TestParams params) {
+        hashThenPrfToZn = params.hashThenPrfToZn;
+        hashPreimageSupplier = params.hashPreimageSupplier;
+    }
+
+    @org.junit.Test
+    public void testRun() {
+        PrfKey k = hashThenPrfToZn.generateKey();
+        assertNotNull(hashThenPrfToZn.hashThenPrfToZn(k, hashPreimageSupplier.get()));
+    }
+
+    @org.junit.Test
+    public void testVector() {
+        PrfKey k = hashThenPrfToZn.generateKey();
+        UniqueByteRepresentable preimage = hashPreimageSupplier.get();
+
+        assertNotNull(hashThenPrfToZn.hashThenPrfToZnVector(k, preimage, 13));
+        assertNotEquals(
+                hashThenPrfToZn.hashThenPrfToZnVector(k, preimage, 12, "preimage1"),
+                hashThenPrfToZn.hashThenPrfToZnVector(k, preimage, 12, "preimage2")
+        );
+        assertNotEquals(
+                hashThenPrfToZn.hashThenPrfToZnVector(k, preimage, 12, "preimage2"),
+                hashThenPrfToZn.hashThenPrfToZnVector(k, preimage, 12, "")
+        );
+        assertNotEquals(
+                hashThenPrfToZn.hashThenPrfToZnVector(k, preimage, 7),
+                hashThenPrfToZn.hashThenPrfToZnVector(k, preimage, 12).truncate(7)
+        ); // Different size vectors should have different elements
+        assertEquals(
+                hashThenPrfToZn.hashThenPrfToZnVector(k, preimage, 7, "samePreimage"),
+                hashThenPrfToZn.hashThenPrfToZnVector(k, preimage, 7, "samePreimage")
+        );
+    }
+
+    // Some test configurations
+    @Parameterized.Parameters(name = "Test: {0}") // add (name="Test: {0}") for jUnit 4.12+ to print ring's name to test
+    public static Collection<TestParams[]> data() {
+        return Arrays.asList(new TestParams[][]{
+                {new TestParams(128, new SHA256HashFunction(), 30, () -> ByteArrayImpl.fromRandom(1024))},
+                {new TestParams(128, new SHA256HashFunction(), 470, () -> ByteArrayImpl.fromRandom(1024))},
+                {new TestParams(128, new SHA256HashFunction(), 1330, () -> ByteArrayImpl.fromRandom(1024))},
+                {new TestParams(128, new SHA512HashFunction(), 470, () -> ByteArrayImpl.fromRandom(1024))},
+                {new TestParams(256, new SHA256HashFunction(), 30, () -> ByteArrayImpl.fromRandom(1024))},
+                {new TestParams(256, new SHA256HashFunction(), 470, () -> ByteArrayImpl.fromRandom(1024))},
+                {new TestParams(256, new SHA256HashFunction(), 1330, () -> ByteArrayImpl.fromRandom(1024))},
+                {new TestParams(256, new SHA512HashFunction(), 470, () -> ByteArrayImpl.fromRandom(1024))},
+        });
+    }
+
+    /**
+     * Simple data class for test parameters.
+     */
+    private static class TestParams {
+        private int aesKeyLength;
+        private HashFunction hashFunction;
+        private Zn zn;
+        private Supplier<UniqueByteRepresentable> hashPreimageSupplier;
+        private HashThenPrfToZn hashThenPrfToZn;
+        private int znBitLength;
+
+        public TestParams(int aesKeyLength, HashFunction hashFunction, int znBitLength, Supplier<UniqueByteRepresentable> hashPreimageSupplier) {
+            this.aesKeyLength = aesKeyLength;
+            this.hashFunction = hashFunction;
+            this.hashPreimageSupplier = hashPreimageSupplier;
+            this.zn = new Zn(new BigInteger(znBitLength, 64, new Random()));
+            this.hashThenPrfToZn = new HashThenPrfToZn(aesKeyLength, zn, hashFunction, 128);
+            this.znBitLength = znBitLength;
+        }
+
+        @Override
+        public String toString() {
+            return aesKeyLength + "bit AES with " + hashFunction.getClass().getName() + ", Zn of size " + znBitLength;
+        }
+    }
+}

--- a/src/test/java/org/cryptimeleon/math/prf/PrfTest.java
+++ b/src/test/java/org/cryptimeleon/math/prf/PrfTest.java
@@ -1,0 +1,78 @@
+package org.cryptimeleon.math.prf;
+
+import org.cryptimeleon.math.misc.ByteArrayImpl;
+import org.cryptimeleon.math.prf.aes.AesPseudorandomFunction;
+import org.cryptimeleon.math.prf.zn.LongAesPseudoRandomFunction;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.function.Supplier;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Does generic testing of rings
+ */
+@RunWith(Parameterized.class)
+public class PrfTest {
+    private PseudorandomFunction prf;
+    private Supplier<PrfPreimage> preimageSupplier;
+
+    public PrfTest(TestParams params) {
+        this.prf = params.prf;
+        this.preimageSupplier = params.preimageSupplier;
+    }
+
+    @Test
+    public void testRun() {
+        PrfKey k = prf.generateKey();
+        assertNotNull(prf.evaluate(k, preimageSupplier.get()));
+    }
+
+    @Test
+    public void testSerialization() {
+        PrfKey k = prf.generateKey();
+        assertEquals(k, prf.restoreKey(k.getRepresentation()));
+
+        PrfPreimage x = preimageSupplier.get();
+        assertEquals(x, prf.restorePreimage(x.getRepresentation()));
+
+        PrfImage y = prf.evaluate(k, x);
+        assertEquals(y, prf.restoreImage(y.getRepresentation()));
+    }
+
+    @Parameters(name = "Test: {0}") // add (name="Test: {0}") for jUnit 4.12+ to print ring's name to test
+    public static Collection<TestParams[]> data() {
+        // AES
+        AesPseudorandomFunction aes = new AesPseudorandomFunction(128);
+        // Long
+        LongAesPseudoRandomFunction longAes = new LongAesPseudoRandomFunction(aes, 7);
+
+        // Collect parameters
+        TestParams params[][] = new TestParams[][]{
+                {new TestParams(aes, () -> ByteArrayImpl.fromRandom(128 / 8))},
+                {new TestParams(longAes, () -> ByteArrayImpl.fromRandom(128 / 8))}
+        };
+        return Arrays.asList(params);
+    }
+
+    private static class TestParams {
+        private PseudorandomFunction prf;
+        private Supplier<PrfPreimage> preimageSupplier;
+
+        public TestParams(PseudorandomFunction prf, Supplier<PrfPreimage> preimageSupplier) {
+            this.prf = prf;
+            this.preimageSupplier = preimageSupplier;
+        }
+
+        @Override
+        public String toString() {
+            return prf.getClass().getName() + " - " + prf.toString();
+        }
+    }
+}

--- a/src/test/java/org/cryptimeleon/math/prf/PrfTest.java
+++ b/src/test/java/org/cryptimeleon/math/prf/PrfTest.java
@@ -2,7 +2,7 @@ package org.cryptimeleon.math.prf;
 
 import org.cryptimeleon.math.misc.ByteArrayImpl;
 import org.cryptimeleon.math.prf.aes.AesPseudorandomFunction;
-import org.cryptimeleon.math.prf.zn.LongAesPseudoRandomFunction;
+import org.cryptimeleon.math.prf.aes.LongAesPseudoRandomFunction;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;

--- a/src/test/java/org/cryptimeleon/math/serialization/standalone/params/PrfStandaloneReprTests.java
+++ b/src/test/java/org/cryptimeleon/math/serialization/standalone/params/PrfStandaloneReprTests.java
@@ -1,0 +1,27 @@
+package org.cryptimeleon.math.serialization.standalone.params;
+
+import org.cryptimeleon.math.hash.impl.SHA256HashFunction;
+import org.cryptimeleon.math.prf.aes.AesPseudorandomFunction;
+import org.cryptimeleon.math.prf.zn.HashThenPrfToZn;
+import org.cryptimeleon.math.prf.zn.LongAesPseudoRandomFunction;
+import org.cryptimeleon.math.serialization.standalone.StandaloneReprSubTest;
+import org.cryptimeleon.math.structures.rings.zn.Zn;
+
+import java.math.BigInteger;
+import java.util.Random;
+
+public class PrfStandaloneReprTests extends StandaloneReprSubTest {
+    public void testAes() {
+        test(new AesPseudorandomFunction(128));
+    }
+
+    public void testLongAes() {
+        test(new LongAesPseudoRandomFunction(new AesPseudorandomFunction(128), 9));
+    }
+
+    public void testAesToZn() {
+        BigInteger p = BigInteger.probablePrime(400, new Random());
+        Zn zn = new Zn(p);
+        test(new HashThenPrfToZn(128, zn, new SHA256HashFunction(), 64));
+    }
+}

--- a/src/test/java/org/cryptimeleon/math/serialization/standalone/params/PrfStandaloneReprTests.java
+++ b/src/test/java/org/cryptimeleon/math/serialization/standalone/params/PrfStandaloneReprTests.java
@@ -3,7 +3,7 @@ package org.cryptimeleon.math.serialization.standalone.params;
 import org.cryptimeleon.math.hash.impl.SHA256HashFunction;
 import org.cryptimeleon.math.prf.aes.AesPseudorandomFunction;
 import org.cryptimeleon.math.prf.zn.HashThenPrfToZn;
-import org.cryptimeleon.math.prf.zn.LongAesPseudoRandomFunction;
+import org.cryptimeleon.math.prf.aes.LongAesPseudoRandomFunction;
 import org.cryptimeleon.math.serialization.standalone.StandaloneReprSubTest;
 import org.cryptimeleon.math.structures.rings.zn.Zn;
 


### PR DESCRIPTION
Adds prf classes and tests from Craco. Includes the `ByteArrayImplementation` class as that is used by the prf stuff.