### PR TITLE
Add (multi-)exp algorithm selection options to debug group

### DIFF
--- a/src/main/java/org/cryptimeleon/math/structures/groups/debug/DebugBilinearGroup.java
+++ b/src/main/java/org/cryptimeleon/math/structures/groups/debug/DebugBilinearGroup.java
@@ -8,6 +8,8 @@ import org.cryptimeleon.math.structures.groups.Group;
 import org.cryptimeleon.math.structures.groups.HashIntoGroup;
 import org.cryptimeleon.math.structures.groups.elliptic.BilinearGroup;
 import org.cryptimeleon.math.structures.groups.elliptic.BilinearMap;
+import org.cryptimeleon.math.structures.groups.exp.ExpAlgorithm;
+import org.cryptimeleon.math.structures.groups.exp.MultiExpAlgorithm;
 import org.cryptimeleon.math.structures.groups.lazy.LazyBilinearGroup;
 import org.cryptimeleon.math.structures.groups.mappings.GroupHomomorphism;
 import org.cryptimeleon.math.structures.rings.zn.Zn;
@@ -57,6 +59,19 @@ public class DebugBilinearGroup implements BilinearGroup {
      * The underlying bilinear map used for applying the pairing function and counting it.
      */
     protected DebugBilinearMap bilMap;
+
+    /**
+     * The debug group for G1.
+     */
+    protected DebugGroup g1;
+    /**
+     * The debug group for G2.
+     */
+    protected DebugGroup g2;
+    /**
+     * The debug group for GT.
+     */
+    protected DebugGroup gT;
 
     /**
      * Initializes this bilinear group with the given security level, pairing type, and group order factoring
@@ -111,25 +126,28 @@ public class DebugBilinearGroup implements BilinearGroup {
     }
 
     /**
-     * Initializes the underlying bilinear map {@link #bilMap}.
+     * Initializes the internal debug objects.
      */
     protected void init() {
         bilMap = new DebugBilinearMap(totalBilGroup.getBilinearMap(), expMultiExpBilGroup.getBilinearMap());
+        g1 = new DebugGroup(totalBilGroup.getG1(), expMultiExpBilGroup.getG1());
+        g2 = new DebugGroup(totalBilGroup.getG2(), expMultiExpBilGroup.getG2());
+        gT = new DebugGroup(totalBilGroup.getGT(), expMultiExpBilGroup.getGT());
     }
 
     @Override
     public Group getG1() {
-        return new DebugGroup(totalBilGroup.getG1(), expMultiExpBilGroup.getG1());
+        return g1;
     }
 
     @Override
     public Group getG2() {
-        return new DebugGroup(totalBilGroup.getG2(), expMultiExpBilGroup.getG2());
+        return g2;
     }
 
     @Override
     public Group getGT() {
-        return new DebugGroup(totalBilGroup.getGT(), expMultiExpBilGroup.getGT());
+        return gT;
     }
 
     @Override
@@ -223,5 +241,101 @@ public class DebugBilinearGroup implements BilinearGroup {
      */
     public String formatCounterData() {
         return bilMap.formatCounterData();
+    }
+
+    /**
+     * Returns the window size used for the non-cached precomputations computed during the exponentiation algorithm
+     * if G1, G2, and GT use the same one; otherwise -1.
+     */
+    public int getExponentiationWindowSize() {
+        if (g1.getExponentiationWindowSize() == g2.getExponentiationWindowSize()) {
+            if (g2.getExponentiationWindowSize() == gT.getExponentiationWindowSize()) {
+                return g1.getExponentiationWindowSize();
+            }
+        }
+        return -1;
+    }
+
+    /**
+     * Sets the window size used for used for the non-cached precomputations computed during the
+     * exponentiation algorithm for G1, G2, and GT at once.
+     * <p>
+     * A larger window size leads to an exponential increase in the number of precomputations done during
+     * exponentiation. As the precomputations affected by this variable are only temporarily stored during execution
+     * of the exponentiation algorithm, we do not recommend setting this too high as the cost of computing the
+     * whole window quickly exceeds its performance benefits during the actual exponentiation.
+     * <p>
+     * If you want to change the number of cached precomputations, use {@link this#setPrecomputationWindowSize(int)}.
+     */
+    public void setExponentiationWindowSize(int exponentiationWindowSize) {
+        g1.setExponentiationWindowSize(exponentiationWindowSize);
+        g2.setExponentiationWindowSize(exponentiationWindowSize);
+        gT.setExponentiationWindowSize(exponentiationWindowSize);
+    }
+
+    /**
+     * Returns the window size used for the precomputations if G1, G2, and GT use the same one; otherwise -1.
+     */
+    public int getPrecomputationWindowSize() {
+        if (g1.getPrecomputationWindowSize() == g2.getPrecomputationWindowSize()) {
+            if (g2.getPrecomputationWindowSize() == gT.getPrecomputationWindowSize()) {
+                return g1.getPrecomputationWindowSize();
+            }
+        }
+        return -1;
+    }
+
+    /**
+     * Sets the window size used for the cached precomputations for G1, G2, and GT at once.
+     * <p>
+     * A larger window size leads to an exponential increase in the number of cached precomputations done but
+     * can also improve the performance of later exponentiations.
+     */
+    public void setPrecomputationWindowSize(int precomputationWindowSize) {
+        g1.setPrecomputationWindowSize(precomputationWindowSize);
+        g2.setPrecomputationWindowSize(precomputationWindowSize);
+        gT.setPrecomputationWindowSize(precomputationWindowSize);
+    }
+
+    /**
+     * Returns the selected multi-exponentiation algorithm if G1, G2, and GT use the same one; otherwise null.
+     */
+    public MultiExpAlgorithm getSelectedMultiExpAlgorithm() {
+        if (g1.getSelectedMultiExpAlgorithm() == g2.getSelectedMultiExpAlgorithm()) {
+            if (g2.getSelectedMultiExpAlgorithm() == gT.getSelectedMultiExpAlgorithm()) {
+                return g1.getSelectedMultiExpAlgorithm();
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Sets the multi-exponentiation algorithm used for G1, G2, and GT at once.
+     */
+    public void setSelectedMultiExpAlgorithm(MultiExpAlgorithm selectedMultiExpAlgorithm) {
+        g1.setSelectedMultiExpAlgorithm(selectedMultiExpAlgorithm);
+        g2.setSelectedMultiExpAlgorithm(selectedMultiExpAlgorithm);
+        gT.setSelectedMultiExpAlgorithm(selectedMultiExpAlgorithm);
+    }
+
+    /**
+     * Returns the selected exponentiation algorithm if G1, G2, and GT use the same one; otherwise null.
+     */
+    public ExpAlgorithm getSelectedExpAlgorithm() {
+        if (g1.getSelectedExpAlgorithm() == g2.getSelectedExpAlgorithm()) {
+            if (g2.getSelectedExpAlgorithm() == gT.getSelectedExpAlgorithm()) {
+                return g1.getSelectedExpAlgorithm();
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Sets the exponentiation algorithm used for G1, G2, and GT at once.
+     */
+    public void setSelectedExpAlgorithm(ExpAlgorithm selectedExpAlgorithm) {
+        g1.setSelectedExpAlgorithm(selectedExpAlgorithm);
+        g2.setSelectedExpAlgorithm(selectedExpAlgorithm);
+        gT.setSelectedExpAlgorithm(selectedExpAlgorithm);
     }
 }

--- a/src/main/java/org/cryptimeleon/math/structures/groups/debug/DebugBilinearGroup.java
+++ b/src/main/java/org/cryptimeleon/math/structures/groups/debug/DebugBilinearGroup.java
@@ -215,7 +215,8 @@ public class DebugBilinearGroup implements BilinearGroup {
     @Override
     public String toString() {
         return "DebugBilinearGroup of type " + pairingType
-                + " simulating security level of " + securityParameter + " bits";
+                + " simulating security level of " + securityParameter + " bits"
+                + " using groups of size " + g1.size();
     }
 
     /**

--- a/src/main/java/org/cryptimeleon/math/structures/groups/debug/DebugBilinearGroup.java
+++ b/src/main/java/org/cryptimeleon/math/structures/groups/debug/DebugBilinearGroup.java
@@ -212,6 +212,12 @@ public class DebugBilinearGroup implements BilinearGroup {
         return Objects.hash(totalBilGroup, expMultiExpBilGroup, bilMap);
     }
 
+    @Override
+    public String toString() {
+        return "DebugBilinearGroup of type " + pairingType
+                + " simulating security level of " + securityParameter + " bits";
+    }
+
     /**
      * Returns the number of pairings computed in this bilinear group.
      */
@@ -231,9 +237,9 @@ public class DebugBilinearGroup implements BilinearGroup {
      */
     public void resetCounters() {
         resetNumPairings();
-        ((DebugGroup) getG1()).resetCounters();
-        ((DebugGroup) getG2()).resetCounters();
-        ((DebugGroup) getGT()).resetCounters();
+        g1.resetCounters();
+        g2.resetCounters();
+        gT.resetCounters();
     }
 
     /**

--- a/src/main/java/org/cryptimeleon/math/structures/groups/debug/DebugGroup.java
+++ b/src/main/java/org/cryptimeleon/math/structures/groups/debug/DebugGroup.java
@@ -302,6 +302,7 @@ public class DebugGroup implements Group {
 
     @Override
     public String toString() {
-        return this.getClass().getSimpleName() + "(" + groupTotal + ";" + groupExpMultiExp + ")";
+        DebugGroupImpl debugImpl = (DebugGroupImpl) groupTotal.getImpl();
+        return this.getClass().getSimpleName() + " with name " + debugImpl.name + " of size " + debugImpl.size();
     }
 }

--- a/src/main/java/org/cryptimeleon/math/structures/groups/debug/DebugGroup.java
+++ b/src/main/java/org/cryptimeleon/math/structures/groups/debug/DebugGroup.java
@@ -235,7 +235,7 @@ public class DebugGroup implements Group {
     }
 
     /**
-     * Allows setting the window size used for used for the non-cached precomputations computed during the
+     * Sets the window size used for used for the non-cached precomputations computed during the
      * exponentiation algorithm.
      * <p>
      * A larger window size leads to an exponential increase in the number of precomputations done during
@@ -258,7 +258,7 @@ public class DebugGroup implements Group {
     }
 
     /**
-     * Allows setting the window size used for the cached precomputations.
+     * Sets the window size used for the cached precomputations.
      * <p>
      * A larger window size leads to an exponential increase in the number of cached precomputations done but
      * can also improve the performance of later exponentiations.

--- a/src/main/java/org/cryptimeleon/math/structures/groups/debug/DebugGroup.java
+++ b/src/main/java/org/cryptimeleon/math/structures/groups/debug/DebugGroup.java
@@ -5,6 +5,8 @@ import org.cryptimeleon.math.serialization.annotations.ReprUtil;
 import org.cryptimeleon.math.serialization.annotations.Represented;
 import org.cryptimeleon.math.structures.groups.Group;
 import org.cryptimeleon.math.structures.groups.GroupElement;
+import org.cryptimeleon.math.structures.groups.exp.ExpAlgorithm;
+import org.cryptimeleon.math.structures.groups.exp.MultiExpAlgorithm;
 import org.cryptimeleon.math.structures.groups.lazy.LazyGroup;
 import org.cryptimeleon.math.structures.groups.lazy.LazyGroupElement;
 import org.cryptimeleon.math.structures.rings.zn.Zn;
@@ -222,6 +224,66 @@ public class DebugGroup implements Group {
                 + "    Number of terms in each multi-exponentiation: " + getMultiExpTermNumbers() + "\n"
                 + "    Number of retrieved representations (via getRepresentation()): "
                 + getNumRetrievedRepresentations() + "\n";
+    }
+
+    /**
+     * Returns the window size used for the non-cached precomputations computed during the exponentiation algorithm.
+     */
+    public int getExponentiationWindowSize() {
+        // assume they both have the same one
+        return groupTotal.getExponentiationWindowSize();
+    }
+
+    /**
+     * Allows setting the window size used for used for the non-cached precomputations computed during the
+     * exponentiation algorithm.
+     * <p>
+     * A larger window size leads to an exponential increase in the number of precomputations done during
+     * exponentiation. As the precomputations affected by this variable are only temporarily stored during execution
+     * of the exponentiation algorithm, we do not recommend setting this too high as the cost of computing the
+     * whole window quickly exceeds its performance benefits during the actual exponentiation.
+     * <p>
+     * If you want to change the number of cached precomputations, use {@link this#setPrecomputationWindowSize(int)}.
+     */
+    public void setExponentiationWindowSize(int exponentiationWindowSize) {
+        groupTotal.setExponentiationWindowSize(exponentiationWindowSize);
+        groupExpMultiExp.setExponentiationWindowSize(exponentiationWindowSize);
+    }
+
+    /**
+     * Returns the window size used for the precomputations.
+     */
+    public int getPrecomputationWindowSize() {
+        return groupTotal.getPrecomputationWindowSize();
+    }
+
+    /**
+     * Allows setting the window size used for the cached precomputations.
+     * <p>
+     * A larger window size leads to an exponential increase in the number of cached precomputations done but
+     * can also improve the performance of later exponentiations.
+     */
+    public void setPrecomputationWindowSize(int precomputationWindowSize) {
+        groupTotal.setPrecomputationWindowSize(precomputationWindowSize);
+        groupExpMultiExp.setPrecomputationWindowSize(precomputationWindowSize);
+    }
+
+    public MultiExpAlgorithm getSelectedMultiExpAlgorithm() {
+        return groupTotal.getSelectedMultiExpAlgorithm();
+    }
+
+    public void setSelectedMultiExpAlgorithm(MultiExpAlgorithm selectedMultiExpAlgorithm) {
+        groupTotal.setSelectedMultiExpAlgorithm(selectedMultiExpAlgorithm);
+        groupExpMultiExp.setSelectedMultiExpAlgorithm(selectedMultiExpAlgorithm);
+    }
+
+    public ExpAlgorithm getSelectedExpAlgorithm() {
+        return groupTotal.getSelectedExpAlgorithm();
+    }
+
+    public void setSelectedExpAlgorithm(ExpAlgorithm selectedExpAlgorithm) {
+        groupTotal.setSelectedExpAlgorithm(selectedExpAlgorithm);
+        groupExpMultiExp.setSelectedExpAlgorithm(selectedExpAlgorithm);
     }
 
     @Override

--- a/src/main/java/org/cryptimeleon/math/structures/groups/lazy/LazyGroup.java
+++ b/src/main/java/org/cryptimeleon/math/structures/groups/lazy/LazyGroup.java
@@ -209,18 +209,41 @@ public class LazyGroup implements Group {
         }
     }
 
+    /**
+     * Returns the window size used for the non-cached precomputations computed during the exponentiation algorithm.
+     */
     public int getExponentiationWindowSize() {
         return exponentiationWindowSize;
     }
 
+    /**
+     * Allows setting the window size used for used for the non-cached precomputations computed during the
+     * exponentiation algorithm.
+     * <p>
+     * A larger window size leads to an exponential increase in the number of precomputations done during
+     * exponentiation. As the precomputations affected by this variable are only temporarily stored during execution
+     * of the exponentiation algorithm, we do not recommend setting this too high as the cost of computing the
+     * whole window quickly exceeds its performance benefits during the actual exponentiation.
+     * <p>
+     * If you want to change the number of cached precomputations, use {@link this#setPrecomputationWindowSize(int)}.
+     */
     public void setExponentiationWindowSize(int exponentiationWindowSize) {
         this.exponentiationWindowSize = exponentiationWindowSize;
     }
 
+    /**
+     * Returns the window size used for the precomputations.
+     */
     public int getPrecomputationWindowSize() {
         return precomputationWindowSize;
     }
 
+    /**
+     * Allows setting the window size used for the cached precomputations.
+     * <p>
+     * A larger window size leads to an exponential increase in the number of cached precomputations done but
+     * can also improve the performance of later exponentiations.
+     */
     public void setPrecomputationWindowSize(int precomputationWindowSize) {
         this.precomputationWindowSize = precomputationWindowSize;
     }


### PR DESCRIPTION
Adds (multi-)exp algorithm selection options to debug group. The same interface as for `LazyGroup` but just for `DebugGroup`. 
Also adds similar methods to `DebugBilinearGroup`, although here some changes have to be made to account for the fact that `DebugBilinearGroup` consists of three groups, G1, G2, and GT.
So the getter methods only return something useful if all of those groups have the same value set. The setter methods apply the change to all of G1, G2, and GT at once.

I also improved the toString methods of `DebugGroup` and `DebugBilinearGroup` to make them more informative.