### PR TITLE
Fix decomposeIntoDigits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Fixed `IntegerRing.decomposeIntoDigits`
+
 ## [2.0.0] - 2021-06-23
 
 ### Added

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 group = 'org.cryptimeleon'
 archivesBaseName = project.name
 boolean isRelease = project.hasProperty("release")
-version = '2.0.0'  + (isRelease ? "" : "-SNAPSHOT")
+version = '2.0.1'  + (isRelease ? "" : "-SNAPSHOT")
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/src/main/java/org/cryptimeleon/math/structures/cartesian/GroupElementExpressionVector.java
+++ b/src/main/java/org/cryptimeleon/math/structures/cartesian/GroupElementExpressionVector.java
@@ -83,6 +83,8 @@ public class GroupElementExpressionVector extends Vector<GroupElementExpression>
             return g.pow((Long) exp);
         if (exp instanceof ExponentExpr)
             return g.pow((ExponentExpr) exp);
+        if (exp instanceof String)
+            return g.pow((String) exp);
         throw new IllegalArgumentException("Cannot compute g^"+exp.getClass().getName());
     }
 

--- a/src/main/java/org/cryptimeleon/math/structures/groups/elliptic/type3/bn/BarretoNaehrigGroup1Impl.java
+++ b/src/main/java/org/cryptimeleon/math/structures/groups/elliptic/type3/bn/BarretoNaehrigGroup1Impl.java
@@ -49,4 +49,9 @@ class BarretoNaehrigGroup1Impl extends BarretoNaehrigSourceGroupImpl {
     public double estimateCostInvPerOp() {
         return 307;
     }
+
+    @Override
+    public String toString() {
+        return "BN G1";
+    }
 }

--- a/src/main/java/org/cryptimeleon/math/structures/groups/elliptic/type3/bn/BarretoNaehrigGroup2Impl.java
+++ b/src/main/java/org/cryptimeleon/math/structures/groups/elliptic/type3/bn/BarretoNaehrigGroup2Impl.java
@@ -47,4 +47,9 @@ class BarretoNaehrigGroup2Impl extends BarretoNaehrigSourceGroupImpl {
     public double estimateCostInvPerOp() {
         return 600;
     }
+
+    @Override
+    public String toString() {
+        return "BN G2";
+    }
 }

--- a/src/main/java/org/cryptimeleon/math/structures/groups/elliptic/type3/bn/BarretoNaehrigSourceGroupImpl.java
+++ b/src/main/java/org/cryptimeleon/math/structures/groups/elliptic/type3/bn/BarretoNaehrigSourceGroupImpl.java
@@ -150,11 +150,7 @@ abstract class BarretoNaehrigSourceGroupImpl extends PairingSourceGroupImpl {
 
     @Override
     public String toString() {
-        String s = "";
-
-        s += "Subgroup of F-rational points on E:x^3+b with b=" + this.getA6().toString();
-
-        return s;
+        return "Subgroup of F-rational points on E:x^3+b with b=" + this.getA6().toString();
     }
 
     @Override

--- a/src/main/java/org/cryptimeleon/math/structures/groups/elliptic/type3/bn/BarretoNaehrigTargetGroupImpl.java
+++ b/src/main/java/org/cryptimeleon/math/structures/groups/elliptic/type3/bn/BarretoNaehrigTargetGroupImpl.java
@@ -41,4 +41,9 @@ class BarretoNaehrigTargetGroupImpl extends PairingTargetGroupImpl {
     public double estimateCostInvPerOp() {
         return 614;
     }
+
+    @Override
+    public String toString() {
+        return "BN GT";
+    }
 }

--- a/src/main/java/org/cryptimeleon/math/structures/rings/integers/IntegerRing.java
+++ b/src/main/java/org/cryptimeleon/math/structures/rings/integers/IntegerRing.java
@@ -6,6 +6,8 @@ import org.cryptimeleon.math.structures.rings.Ring;
 import org.cryptimeleon.math.structures.rings.RingElement;
 
 import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Optional;
 
 /**
@@ -110,14 +112,19 @@ public class IntegerRing implements Ring {
      *      \(\sum_i{ \text{A}[i] \cdot \text{base}^i} = \text{number}\)
      */
     public static BigInteger[] decomposeIntoDigits(BigInteger number, BigInteger base) {
-        int power = 0;
-        BigInteger basePower = BigInteger.ONE;
-        // as soon as number is smaller than base^power, it can be decomposed into power digits.
-        while (basePower.compareTo(number) < 0) {
-            basePower = basePower.multiply(base);
-            power++;
+        if (base.signum() <= 0 || number.signum() < 0)
+            throw new IllegalArgumentException("Parameters must be positive/non-negative");
+
+        ArrayList<BigInteger> result = new ArrayList<>();
+        BigInteger remainingDigits = number;
+
+        while (remainingDigits.signum() != 0) {
+            BigInteger[] div = remainingDigits.divideAndRemainder(base);
+            result.add(div[1]); //current digit
+            remainingDigits = div[0]; // remaining digits
         }
-        return decomposeIntoDigits(number, base, power);
+
+        return result.toArray(new BigInteger[0]);
     }
 
     /**
@@ -134,18 +141,16 @@ public class IntegerRing implements Ring {
             throw new IllegalArgumentException("Parameters must be positive/non-negative");
 
         BigInteger[] result = new BigInteger[numDigits];
-        BigInteger remainder = number;
+        BigInteger remainingDigits = number;
 
-        for (int j = numDigits - 1; j >= 0; j--) {
-            BigInteger basePowJ = base.pow(j);
-            BigInteger[] div = remainder.divideAndRemainder(basePowJ);
-            result[j] = div[0]; // current digit
-            remainder = div[1]; // remainder value (to be represented with the remaining digits)
+        for (int j=0; j < numDigits; j++) {
+            BigInteger[] div = remainingDigits.divideAndRemainder(base);
+            result[j] = div[1]; //current digit
+            remainingDigits = div[0]; // remaining digits
         }
 
-        if (remainder.signum() != 0)
-            throw new IllegalArgumentException("Unable to represent " + number.toString() + " base " + base.toString()
-                    + " with " + numDigits + " digits");
+        if (remainingDigits.signum() != 0)
+            throw new IllegalArgumentException("Unable to represent " + number + " base " + base + " with " + numDigits + " digits");
 
         return result;
     }


### PR DESCRIPTION
The old version decomposed "100" into "[0, 0, 10]" in base 10. Also, it never really threw an exception if the number was too large to write with the given number of digits, it just produced one giant digit to compensate.

The new version does the more usual computation of computing the digits from least significant to most significant. 