### PR TITLE
Remove `Zn#getInteger()` and replace usage with `RingElement#asInteger()`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 group = 'org.cryptimeleon'
 archivesBaseName = project.name
 boolean isRelease = project.hasProperty("release")
-version = '2.1.0'  + (isRelease ? "" : "-SNAPSHOT")
+version = '3.0.0'  + (isRelease ? "" : "-SNAPSHOT")
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/src/main/java/org/cryptimeleon/math/expressions/exponent/ExponentConstantExpr.java
+++ b/src/main/java/org/cryptimeleon/math/expressions/exponent/ExponentConstantExpr.java
@@ -21,7 +21,7 @@ public class ExponentConstantExpr implements ExponentExpr {
     }
 
     public ExponentConstantExpr(Zn.ZnElement exponent) {
-        this.exponent = exponent.getInteger();
+        this.exponent = exponent.asInteger();
     }
 
     public ExponentConstantExpr(long exponent) {

--- a/src/main/java/org/cryptimeleon/math/expressions/group/PairingExpr.java
+++ b/src/main/java/org/cryptimeleon/math/expressions/group/PairingExpr.java
@@ -87,7 +87,7 @@ public class PairingExpr extends AbstractGroupElementExpression {
         }
         else {
             BigInteger groupSize = getGroupOrderIfKnown();
-            BigInteger exponentVal = groupSize == null ? exponent.evaluate() : exponent.evaluate(new Zn(groupSize)).getInteger();
+            BigInteger exponentVal = groupSize == null ? exponent.evaluate() : exponent.evaluate(new Zn(groupSize)).asInteger();
             return new GroupOpExpr(evaluate().pow(exponentVal).expr(), new GroupEmptyExpr(map.getGT()));
         }
     }

--- a/src/main/java/org/cryptimeleon/math/structures/groups/elliptic/BilinearMap.java
+++ b/src/main/java/org/cryptimeleon/math/structures/groups/elliptic/BilinearMap.java
@@ -71,7 +71,7 @@ public interface BilinearMap extends BiFunction<GroupElement, GroupElement, Grou
      * @param exponent the exponent to apply to the result of the pairing
      */
     default GroupElement apply(GroupElement g1, GroupElement g2, Zn.ZnElement exponent) {
-        return apply(g1, g2, exponent.getInteger());
+        return apply(g1, g2, exponent.asInteger());
     }
 
     /**

--- a/src/main/java/org/cryptimeleon/math/structures/groups/elliptic/PairingSourceGroupImpl.java
+++ b/src/main/java/org/cryptimeleon/math/structures/groups/elliptic/PairingSourceGroupImpl.java
@@ -207,7 +207,7 @@ public abstract class PairingSourceGroupImpl implements WeierstrassCurve {
     @Override
     public PairingSourceGroupElement getUniformlyRandomElement() throws UnsupportedOperationException {
         Zp zp = new Zp(this.size());
-        return (PairingSourceGroupElement) this.getGenerator().pow(zp.getUniformlyRandomElement().getInteger());
+        return (PairingSourceGroupElement) this.getGenerator().pow(zp.getUniformlyRandomElement().asInteger());
     }
 
     @Override

--- a/src/main/java/org/cryptimeleon/math/structures/groups/elliptic/PairingTargetGroupImpl.java
+++ b/src/main/java/org/cryptimeleon/math/structures/groups/elliptic/PairingTargetGroupImpl.java
@@ -86,7 +86,7 @@ public abstract class PairingTargetGroupImpl implements GroupImpl, Representable
          * exponentiation,
          *  at least unless we use structure of cofactor*/
         return (PairingTargetGroupElementImpl) this.getGenerator().pow(
-                (new Zp(this.size()).getUniformlyRandomElement()).getInteger());
+                (new Zp(this.size()).getUniformlyRandomElement()).asInteger());
     }
 
     @Override

--- a/src/main/java/org/cryptimeleon/math/structures/groups/elliptic/type1/supersingular/SupersingularSourceGroupImpl.java
+++ b/src/main/java/org/cryptimeleon/math/structures/groups/elliptic/type1/supersingular/SupersingularSourceGroupImpl.java
@@ -105,7 +105,7 @@ class SupersingularSourceGroupImpl extends PairingSourceGroupImpl {
     @Override
     public SupersingularSourceGroupElementImpl getUniformlyRandomElement() throws UnsupportedOperationException {
         if (getSize().compareTo(getCofactor()) < 0 && generator != null) { //cheaper to just do rndInt*generator as the steps below include cofactor multiplcation
-            return (SupersingularSourceGroupElementImpl) getGenerator().pow(new Zn(getSize()).getUniformlyRandomElement().getInteger());
+            return (SupersingularSourceGroupElementImpl) getGenerator().pow(new Zn(getSize()).getUniformlyRandomElement().asInteger());
         } else {
             return mapToPoint((ExtensionFieldElement) getFieldOfDefinition().getUniformlyRandomElement());
         }

--- a/src/main/java/org/cryptimeleon/math/structures/groups/elliptic/type1/supersingular/SupersingularSourceHash.java
+++ b/src/main/java/org/cryptimeleon/math/structures/groups/elliptic/type1/supersingular/SupersingularSourceHash.java
@@ -32,7 +32,7 @@ class SupersingularSourceHash implements HashIntoGroupImpl {
     public GroupElementImpl hashIntoGroupImpl(byte[] x) {
         HashIntoZn hash = new HashIntoZn(this.codomain.getFieldOfDefinition().size());
         ExtensionFieldElement z = ((ExtensionField) this.codomain.getFieldOfDefinition()).createElement(
-                hash.hash(x).getInteger()
+                hash.hash(x).asInteger()
         );
         return this.codomain.mapToPoint(z);
     }

--- a/src/main/java/org/cryptimeleon/math/structures/rings/RingElement.java
+++ b/src/main/java/org/cryptimeleon/math/structures/rings/RingElement.java
@@ -211,6 +211,8 @@ public interface RingElement extends Element {
     /**
      * Interprets this element as an integer.
      * <p>
+     * Result will be between 0 and the ring's characteristic.
+     * <p>
      * Formally, this method shall return the inverse of {@link Ring#getElement(BigInteger)}, i.e.
      * {@code x.getStructure().getElement(x.asInteger()).equals(x)} (if {@code asInteger()} doesn't throw an exception).
      *

--- a/src/main/java/org/cryptimeleon/math/structures/rings/polynomial/LagrangeUtils.java
+++ b/src/main/java/org/cryptimeleon/math/structures/rings/polynomial/LagrangeUtils.java
@@ -99,6 +99,6 @@ public class LagrangeUtils {
                 field.createZnElement(i),
                 S.parallelStream().map(field::createZnElement).collect(Collectors.toSet()),
                 field.createZnElement(x)
-        ).getInteger();
+        ).asInteger();
     }
 }

--- a/src/main/java/org/cryptimeleon/math/structures/rings/zn/Zn.java
+++ b/src/main/java/org/cryptimeleon/math/structures/rings/zn/Zn.java
@@ -42,7 +42,7 @@ public class Zn implements Ring {
     protected Boolean nIsPrime = null;
 
     /**
-     * Maximum value (over all elements elem) of {@code elem.getInteger().toByteArray().length;}.
+     * Maximum value (over all elements elem) of {@code elem.asInteger().toByteArray().length;}.
      * The value is exactly the number of bytes needed to represent n.
      */
     protected final int maxByteLength;
@@ -291,13 +291,6 @@ public class Zn implements Ring {
         @Override
         public Representation getRepresentation() {
             return new BigIntegerRepresentation(v);
-        }
-
-        /**
-         * Returns the unique integer representative for this element in \([0,n)\).
-         */
-        public BigInteger getInteger() {
-            return v;
         }
 
         @Override

--- a/src/test/java/org/cryptimeleon/math/structures/GroupImplTests.java
+++ b/src/test/java/org/cryptimeleon/math/structures/GroupImplTests.java
@@ -95,7 +95,7 @@ public class GroupImplTests {
             assertTrue("Lagrange", a.pow(size).isNeutralElement());
             assertTrue("Lagrange inversion", a.pow(size.subtract(BigInteger.ONE)).equals(a.inv()));
 
-            BigInteger r = new Zn(groupImpl.size()).getUniformlyRandomElement().getInteger();
+            BigInteger r = new Zn(groupImpl.size()).getUniformlyRandomElement().asInteger();
             if (size.isProbablePrime(100)) {
                 // If commutative: (ab)^r b^{-r} = a^r
                 assertTrue(a.op(b).pow(r).op(b.pow(r.negate())).equals(a.pow(r)));

--- a/src/test/java/org/cryptimeleon/math/structures/GroupTests.java
+++ b/src/test/java/org/cryptimeleon/math/structures/GroupTests.java
@@ -138,7 +138,7 @@ public class GroupTests {
             assertTrue("Lagrange", a.pow(size).isNeutralElement());
             assertEquals("Lagrange inversion", a.pow(size.subtract(BigInteger.ONE)), a.inv());
 
-            BigInteger r = new Zn(group.size()).getUniformlyRandomElement().getInteger();
+            BigInteger r = new Zn(group.size()).getUniformlyRandomElement().asInteger();
             if (size.isProbablePrime(100)) {
                 // If commutative: (ab)^r b^{-r} = a^r
                 assertEquals(a.op(b).pow(r).op(b.pow(r.negate())), a.pow(r));


### PR DESCRIPTION
Completely removes `getInteger` and replaces all usages with `asInteger`.