### PR TITLE
Passing exceptions on group op worker threads to waiting threads.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add lazy and naive wrappers around `Secp256k1` curve, and make curve implementation package-private
 
+### Fixed
+- Fixed [issue](https://github.com/cryptimeleon/math/pull/134) where exceptions during group computations could hang up the whole applications without surfacing the exception.
 
 ## [2.1.0]
 


### PR DESCRIPTION
Previously, when an exception occured during some computation (say, you're trying to compute e(g2, g2)), the worker thread just swallowed the exception and the waiting (main) thread hangs forever, waiting for a result whose computation was aborted. 

This often gave the appearance that the program hangs because some race condition appeared. The actual error was never actually displayed if the computation happened on a background thread.

With this pull request, any errors are now also passed to threads waiting for the computation to finish, so exceptions are now properly displayed and programs won't hang mysteriously anymore.