### PR TITLE
Fix linearize

### DIFF
--- a/src/main/java/org/cryptimeleon/math/expressions/group/GroupPowExpr.java
+++ b/src/main/java/org/cryptimeleon/math/expressions/group/GroupPowExpr.java
@@ -2,6 +2,7 @@ package org.cryptimeleon.math.expressions.group;
 
 import org.cryptimeleon.math.expressions.Expression;
 import org.cryptimeleon.math.expressions.Substitution;
+import org.cryptimeleon.math.expressions.exponent.ExponentEmptyExpr;
 import org.cryptimeleon.math.expressions.exponent.ExponentExpr;
 import org.cryptimeleon.math.expressions.exponent.ExponentSumExpr;
 import org.cryptimeleon.math.structures.groups.GroupElement;
@@ -74,10 +75,16 @@ public class GroupPowExpr extends AbstractGroupElementExpression {
 
         if (baseHasVariables) { //hence exponent doesn't
             GroupOpExpr baseLinear = base.linearize();
-            return new GroupOpExpr(baseLinear.getLhs().pow(exponent), baseLinear.getRhs().pow(exponent));
+            if (baseLinear.getLhs() instanceof GroupEmptyExpr) //base is linear already, hence this PowExpr is linear
+                return new GroupOpExpr(new GroupEmptyExpr(base.getGroup()), this);
+            else //split base into linear and constant part
+                return new GroupOpExpr(baseLinear.getLhs().pow(exponent), baseLinear.getRhs().pow(exponent));
         } else { //exponent has variables, base doesn't.
             ExponentSumExpr exponentLinear = exponent.linearize();
-            return new GroupOpExpr(base.pow(exponentLinear.getLhs()), base.pow(exponentLinear.getRhs()));
+            if (exponentLinear.getLhs() instanceof ExponentEmptyExpr) //exponent is linear already, hence this PowExpr is linear
+                return new GroupOpExpr(new GroupEmptyExpr(base.getGroup()), this);
+            else //split exponent into linear and constant part
+                return new GroupOpExpr(base.pow(exponentLinear.getLhs()), base.pow(exponentLinear.getRhs()));
         }
     }
 

--- a/src/main/java/org/cryptimeleon/math/expressions/group/PairingExpr.java
+++ b/src/main/java/org/cryptimeleon/math/expressions/group/PairingExpr.java
@@ -73,10 +73,16 @@ public class PairingExpr extends AbstractGroupElementExpression {
 
         if (lhsHasVariables) { //hence rhs doesn't
             GroupOpExpr lhsLinearized = lhs.linearize();
-            return new GroupOpExpr(new PairingExpr(map, lhsLinearized.getLhs(), rhs), new PairingExpr(map, lhsLinearized.getRhs(), rhs));
+            if (lhsLinearized.getLhs() instanceof GroupEmptyExpr) //lhs is already linearized, so this PairingExpr is already linear
+                return new GroupOpExpr(new GroupEmptyExpr(map.getGT()), this);
+            else
+                return new GroupOpExpr(new PairingExpr(map, lhsLinearized.getLhs(), rhs), new PairingExpr(map, lhsLinearized.getRhs(), rhs));
         } else { //lhs is constant, rhs isn't
             GroupOpExpr rhsLinearized = rhs.linearize();
-            return new GroupOpExpr(new PairingExpr(map, lhs, rhsLinearized.getLhs()), new PairingExpr(map, lhs, rhsLinearized.getRhs()));
+            if (rhsLinearized.getLhs() instanceof GroupEmptyExpr) //rhs is already linearized, so this PairingExpr is already linear
+                return new GroupOpExpr(new GroupEmptyExpr(map.getGT()), this);
+            else
+                return new GroupOpExpr(new PairingExpr(map, lhs, rhsLinearized.getLhs()), new PairingExpr(map, lhs, rhsLinearized.getRhs()));
         }
     }
 

--- a/src/main/java/org/cryptimeleon/math/structures/groups/debug/DebugGroup.java
+++ b/src/main/java/org/cryptimeleon/math/structures/groups/debug/DebugGroup.java
@@ -481,7 +481,7 @@ public class DebugGroup implements Group {
                 result.append(formatCounterData(bucketName, false, false));
             }
         }
-        return result.append(formatCounterDataAllBuckets(false)).toString();
+        return result.append(formatCounterDataAllBucketsOnly(false)).toString();
     }
 
     /**


### PR DESCRIPTION
Previously, linearization of GroupElementExpressions sometimes produced some additional unnecessary neutral element factors, which had negative effects on protocol performance.